### PR TITLE
Wrap pages with SiteLayout

### DIFF
--- a/client/src/pages/about-page.tsx
+++ b/client/src/pages/about-page.tsx
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 import { Content } from '@shared/schema';
 
 export default function AboutPage() {
@@ -197,22 +196,18 @@ export default function AboutPage() {
   };
 
   return (
-    <>
-      <SEOHead 
-        title={`${defaultContent.title} | ness.`}
-        description={
-          language === 'pt' 
-            ? "Conheça a história da ness., empresa com mais de 30 anos de experiência em serviços de tecnologia, infraestrutura e segurança cibernética."
-            : language === 'en'
-              ? "Learn about ness.'s history, a company with over 30 years of experience in technology services, infrastructure, and cybersecurity."
-              : "Conozca la historia de ness., empresa con más de 30 años de experiencia en servicios de tecnología, infraestructura y seguridad cibernética."
-        }
-        canonicalUrl="/about"
-        structuredData={structuredData}
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title={`${defaultContent.title} | ness.`}
+      description={
+        language === 'pt'
+          ? "Conheça a história da ness., empresa com mais de 30 anos de experiência em serviços de tecnologia, infraestrutura e segurança cibernética."
+          : language === 'en'
+            ? "Learn about ness.'s history, a company with over 30 years of experience in technology services, infrastructure, and cybersecurity."
+            : "Conozca la historia de ness., empresa con más de 30 años de experiencia en servicios de tecnología, infraestructura y seguridad cibernética."
+      }
+      canonicalUrl="/about"
+      structuredData={structuredData}
+    >
       <main>
         {/* Hero Section com estilo abstrato geométrico */}
         <section className="hero-abstract">
@@ -542,8 +537,6 @@ export default function AboutPage() {
           </div>
         </section>
       </main>
-      
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -5,9 +5,8 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuth } from '@/hooks/use-auth';
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -79,15 +78,11 @@ export default function AuthPage() {
   }
   
   return (
-    <>
-      <SEOHead 
-        title="Login - ness."
-        description="Faça login para acessar a área administrativa da ness."
-        canonicalUrl="/auth"
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title="Login - ness."
+      description="Faça login para acessar a área administrativa da ness."
+      canonicalUrl="/auth"
+    >
       <main className="py-20 bg-neutral min-h-screen">
         <div className="container mx-auto px-4 pt-16">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
@@ -305,7 +300,6 @@ export default function AuthPage() {
         </div>
       </main>
       
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/contact-page.tsx
+++ b/client/src/pages/contact-page.tsx
@@ -1,8 +1,7 @@
 import { useState, useRef } from 'react';
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -85,15 +84,11 @@ export default function ContactPage() {
   const heroBackground = "https://images.unsplash.com/photo-1560264280-88b68371db39?auto=format&fit=crop&w=1920&h=1080&q=80";
 
   return (
-    <>
-      <SEOHead 
-        title="Contato - ness."
-        description="Entre em contato com nossa equipe para saber mais sobre nossos serviços de tecnologia e segurança."
-        structuredData={structuredData}
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title="Contato - ness."
+      description="Entre em contato com nossa equipe para saber mais sobre nossos serviços de tecnologia e segurança."
+      structuredData={structuredData}
+    >
       <main>
         <section className="w-full py-32 bg-gradient-to-b from-blue-600 to-blue-800 text-white">
           <div className="container mx-auto px-4">
@@ -367,7 +362,6 @@ export default function ContactPage() {
         </section>
       </main>
       
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/ethics-page.tsx
+++ b/client/src/pages/ethics-page.tsx
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 import { Content } from '@shared/schema';
 
 export default function EthicsPage() {
@@ -103,15 +102,11 @@ export default function EthicsPage() {
   };
 
   return (
-    <>
-      <SEOHead 
-        title={`${content?.title || defaultContent.title} - ness.`}
-        description="Conheça o Código de Ética da ness. e nossos princípios fundamentais para a condução de negócios responsáveis e éticos."
-        canonicalUrl="/ethics"
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title={`${content?.title || defaultContent.title} - ness.`}
+      description="Conheça o Código de Ética da ness. e nossos princípios fundamentais para a condução de negócios responsáveis e éticos."
+      canonicalUrl="/ethics"
+    >
       <main>
         {/* Hero Section */}
         <section className="relative py-20 bg-primary text-white">
@@ -146,7 +141,6 @@ export default function EthicsPage() {
         </section>
       </main>
       
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 import HeroSection from '@/components/sections/HeroSection';
 import ServicesSection from '@/components/sections/ServicesSection';
 import SpinoffsSection from '@/components/sections/SpinoffsSection';
@@ -56,17 +55,13 @@ export default function HomePage() {
   };
 
   return (
-    <>
-      <SEOHead 
-        title="ness. - Transformamos Operações Críticas em Vantagem Estratégica"
-        description="Desde 1991 fornecendo soluções especializadas em segurança, infraestrutura e operações críticas para empresas que buscam vantagem competitiva através da tecnologia."
-        structuredData={structuredData}
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title="ness. - Transformamos Operações Críticas em Vantagem Estratégica"
+      description="Desde 1991 fornecendo soluções especializadas em segurança, infraestrutura e operações críticas para empresas que buscam vantagem competitiva através da tecnologia."
+      structuredData={structuredData}
+    >
       <main>
-        <HeroSection 
+        <HeroSection
           title={t('home.hero.title')}
           subtitle={t('home.hero.subtitle')}
           ctaText1={t('home.hero.cta1')}
@@ -80,13 +75,11 @@ export default function HomePage() {
         
         <SpinoffsSection />
         
-        <StatsSection 
+        <StatsSection
           backgroundImage={statsProps.backgroundImage}
           stats={statsProps.stats}
         />
       </main>
-      
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/jobs-page.tsx
+++ b/client/src/pages/jobs-page.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 import { Job } from '@shared/schema';
 
 export default function JobsPage() {
@@ -26,15 +25,11 @@ export default function JobsPage() {
   const filteredJobs = filterJobs(jobs);
 
   return (
-    <>
-      <SEOHead 
-        title={`${t('jobs.title')} - ness.`}
-        description="Explore as oportunidades de carreira na ness. e junte-se a nossa equipe de especialistas em tecnologia."
-        canonicalUrl="/jobs"
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title={`${t('jobs.title')} - ness.`}
+      description="Explore as oportunidades de carreira na ness. e junte-se a nossa equipe de especialistas em tecnologia."
+      canonicalUrl="/jobs"
+    >
       <main>
         {/* Hero Section */}
         <section className="relative py-20 bg-primary text-white">
@@ -193,7 +188,6 @@ export default function JobsPage() {
         </section>
       </main>
       
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/news-page.tsx
+++ b/client/src/pages/news-page.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 import { News } from '@shared/schema';
 import { formatDate } from '@/lib/utils';
 
@@ -32,15 +31,11 @@ export default function NewsPage() {
     : ['all', 'company', 'technology', 'events'];
 
   return (
-    <>
-      <SEOHead 
-        title={`${t('news.title')} - ness.`}
-        description="Fique por dentro das últimas notícias e atualizações da ness. e do mundo da tecnologia."
-        canonicalUrl="/news"
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title={`${t('news.title')} - ness.`}
+      description="Fique por dentro das últimas notícias e atualizações da ness. e do mundo da tecnologia."
+      canonicalUrl="/news"
+    >
       <main>
         {/* Hero Section com fundo gradiente azul, sem imagem */}
         <section className="relative py-20 bg-gradient-to-b from-blue-600 to-blue-800 text-white">
@@ -169,7 +164,6 @@ export default function NewsPage() {
         </section>
       </main>
       
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/privacy-page.tsx
+++ b/client/src/pages/privacy-page.tsx
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 import { Content } from '@shared/schema';
 
 export default function PrivacyPage() {
@@ -142,15 +141,11 @@ export default function PrivacyPage() {
   };
 
   return (
-    <>
-      <SEOHead 
-        title={`${content?.title || defaultContent.title} - ness.`}
-        description="Conheça nossa Política de Segurança e Privacidade e como tratamos seus dados pessoais com o máximo de segurança e transparência."
-        canonicalUrl="/privacy"
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title={`${content?.title || defaultContent.title} - ness.`}
+      description="Conheça nossa Política de Segurança e Privacidade e como tratamos seus dados pessoais com o máximo de segurança e transparência."
+      canonicalUrl="/privacy"
+    >
       <main>
         {/* Hero Section */}
         <section className="relative py-20 bg-primary text-white">
@@ -185,7 +180,6 @@ export default function PrivacyPage() {
         </section>
       </main>
       
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/services-page.tsx
+++ b/client/src/pages/services-page.tsx
@@ -1,8 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 import { Content, Service } from '@shared/schema';
 
 interface ServiceItemProps {
@@ -103,15 +102,11 @@ export default function ServicesPage() {
   ];
 
   return (
-    <>
-      <SEOHead 
-        title={`${t('services.title')} - ness.`}
-        description="Conheça nossas soluções em segurança da informação, transformação digital e análise de dados para impulsionar seu negócio."
-        canonicalUrl="/services"
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title={`${t('services.title')} - ness.`}
+      description="Conheça nossas soluções em segurança da informação, transformação digital e análise de dados para impulsionar seu negócio."
+      canonicalUrl="/services"
+    >
       <main>
         {/* Hero Section */}
         <section className="relative py-20 bg-primary text-white">
@@ -162,7 +157,6 @@ export default function ServicesPage() {
         </section>
       </main>
       
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/services/infraops-page.tsx
+++ b/client/src/pages/services/infraops-page.tsx
@@ -1,7 +1,6 @@
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 
 export default function InfraOpsPage() {
   const { t } = useI18n();
@@ -47,15 +46,11 @@ export default function InfraOpsPage() {
   const heroBackground = "https://images.unsplash.com/photo-1614064641938-3bbee52942c7?auto=format&fit=crop&w=1920&h=1080&q=80";
 
   return (
-    <>
-      <SEOHead 
-        title="n.InfraOps - Infraestrutura de TI como Vantagem Estratégica | ness."
-        description="Serviços de infraestrutura de TI que garantem disponibilidade, escalabilidade e segurança para suas operações críticas, com monitoramento 24x7 e resposta imediata a incidentes."
-        structuredData={structuredData}
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title="n.InfraOps - Infraestrutura de TI como Vantagem Estratégica | ness."
+      description="Serviços de infraestrutura de TI que garantem disponibilidade, escalabilidade e segurança para suas operações críticas, com monitoramento 24x7 e resposta imediata a incidentes."
+      structuredData={structuredData}
+    >
       <main>
         {/* Hero Section com imagem escurecida */}
         <section className="relative w-full py-32 overflow-hidden">
@@ -181,7 +176,6 @@ export default function InfraOpsPage() {
         </section>
       </main>
       
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }

--- a/client/src/pages/services/secops-page.tsx
+++ b/client/src/pages/services/secops-page.tsx
@@ -1,7 +1,6 @@
 import { useI18n } from '@/lib/i18n';
-import SEOHead from '@/components/common/SEOHead';
-import Navbar from '@/components/layout/Navbar';
-import Footer from '@/components/layout/Footer';
+
+import SiteLayout from '@/site/layout/SiteLayout';
 
 export default function SecOpsPage() {
   const { t } = useI18n();
@@ -47,15 +46,11 @@ export default function SecOpsPage() {
   const heroBackground = "https://images.unsplash.com/photo-1555949963-ff9fe0c870eb?auto=format&fit=crop&w=1920&h=1080&q=80";
 
   return (
-    <>
-      <SEOHead 
-        title="n.SecOps - Serviços Avançados de Segurança Cibernética | ness."
-        description="Proteja sua organização contra ameaças digitais com nossos serviços avançados de segurança cibernética, incluindo SOC 24x7, gestão de vulnerabilidades e resposta a incidentes."
-        structuredData={structuredData}
-      />
-      
-      <Navbar />
-      
+    <SiteLayout
+      title="n.SecOps - Serviços Avançados de Segurança Cibernética | ness."
+      description="Proteja sua organização contra ameaças digitais com nossos serviços avançados de segurança cibernética, incluindo SOC 24x7, gestão de vulnerabilidades e resposta a incidentes."
+      structuredData={structuredData}
+    >
       <main>
         {/* Hero Section com imagem escurecida */}
         <section className="relative w-full py-32 overflow-hidden">
@@ -181,7 +176,6 @@ export default function SecOpsPage() {
         </section>
       </main>
       
-      <Footer />
-    </>
+    </SiteLayout>
   );
 }


### PR DESCRIPTION
## Summary
- wrap major pages with `SiteLayout`
- drop direct `Navbar`/`Footer` usage

## Testing
- `npm run check` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_68404f62cc6c8330ba4ab49dc23a3a39