### PR TITLE
Require SESSION_SECRET for auth sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ npx tsx scripts/export-content.ts
 
 This command scans every folder inside `client/src/site` and `client/src/pages`, collects the strings from their `.tsx` files and writes them into a `<foldername>.txt` file inside that folder.  
 Run it whenever page content changes so the backups stay in sync.
+
+## Environment variables
+
+The server requires a `SESSION_SECRET` environment variable to sign session
+cookies. Set it to a random string before starting the application, e.g.:
+
+```bash
+export SESSION_SECRET="a long random string"
+npm run dev
+```

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -75,7 +75,10 @@ async function ensureAdminUser() {
 }
 
 export function setupAuth(app: Express) {
-  const sessionSecret = process.env.SESSION_SECRET || "ness-secret-key-change-in-production";
+  const sessionSecret = process.env.SESSION_SECRET;
+  if (!sessionSecret) {
+    throw new Error("SESSION_SECRET environment variable is required");
+  }
   
   const sessionSettings: session.SessionOptions = {
     secret: sessionSecret,


### PR DESCRIPTION
## Summary
- halt server startup if `SESSION_SECRET` isn't defined
- document the required environment variable in `README`

## Testing
- `npm run check` *(fails: cannot find type definition file for 'node', plus many TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_68405f58ecec83308319a98ac22830f8