### PR TITLE
Remove default admin setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ npx tsx scripts/export-content.ts
 
 This command scans every folder inside `client/src/site` and `client/src/pages`, collects the strings from their `.tsx` files and writes them into a `<foldername>.txt` file inside that folder.  
 Run it whenever page content changes so the backups stay in sync.
+
+## Admin credentials
+
+The API creates an administrator account at startup using the
+`ADMIN_USER` and `ADMIN_PASSWORD` environment variables.
+Define these variables (for example in a `.env` file) before running the
+development server so the admin user is created automatically.

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -196,15 +196,6 @@ export class MemStorage implements IStorage {
     this.newsId = 1;
     this.activityId = 1;
     
-    // Initialize with admin user
-    this.createUser({
-      username: "admin",
-      password: "$2b$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa", // 'password'
-    }).then(user => {
-      // Update user to be admin
-      const adminUser = { ...user, isAdmin: true };
-      this.users.set(user.id, adminUser);
-    });
     
     // Initialize with default content
     this.initializeDefaultContent();
@@ -694,17 +685,9 @@ export class DatabaseStorage implements IStorage {
     const usersCount = parseInt(result[0]?.count as unknown as string, 10) || 0;
     
     if (usersCount === 0) {
-      console.log("Initializing default admin user...");
-      // Create admin user
-      await this.createUser({
-        username: "admin",
-        password: "$2b$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa", // 'password'
-        isAdmin: true,
-      });
-      
       // Initialize default content
       await this.initializeDefaultContent();
-      
+
       // Initialize sample jobs and news
       await this.initializeSampleJobs();
       await this.initializeSampleNews();


### PR DESCRIPTION
## Summary
- remove hardcoded admin user creation in storage
- document admin credentials configuration

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_68405f5ac6808330ab868ebcca6fa2d5