### PR TITLE
Remove hardcoded admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ cookies. Set it to a random string before starting the application, e.g.:
 export SESSION_SECRET="a long random string"
 npm run dev
 ```
+
+To create the initial administrator account, set `ADMIN_USER` and
+`ADMIN_PASSWORD` before starting the server. The credentials are used by
+`server/auth.ts` to automatically ensure an admin user exists.
+
+When the database is empty the server also populates default page content and
+some sample jobs and news items.

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -196,15 +196,6 @@ export class MemStorage implements IStorage {
     this.newsId = 1;
     this.activityId = 1;
     
-    // Initialize with admin user
-    this.createUser({
-      username: "admin",
-      password: "$2b$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa", // 'password'
-    }).then(user => {
-      // Update user to be admin
-      const adminUser = { ...user, isAdmin: true };
-      this.users.set(user.id, adminUser);
-    });
     
     // Initialize with default content
     this.initializeDefaultContent();
@@ -689,24 +680,24 @@ export class DatabaseStorage implements IStorage {
   
   // Initialize defaults if needed
   private async initializeDefaults() {
-    // Check if users table is empty
-    const result = await db.select({ count: users.id }).from(users);
-    const usersCount = parseInt(result[0]?.count as unknown as string, 10) || 0;
-    
-    if (usersCount === 0) {
-      console.log("Initializing default admin user...");
-      // Create admin user
-      await this.createUser({
-        username: "admin",
-        password: "$2b$10$vI8aWBnW3fID.ZQ4/zo1G.q1lRps.9cGLcZEiGDMVr5yUP1KUOYTa", // 'password'
-        isAdmin: true,
-      });
-      
-      // Initialize default content
+    // Populate default content if none exists
+    const [contentResult] = await db.select({ count: contents.id }).from(contents);
+    const contentCount = parseInt(contentResult?.count as unknown as string, 10) || 0;
+    if (contentCount === 0) {
       await this.initializeDefaultContent();
-      
-      // Initialize sample jobs and news
+    }
+
+    // Populate sample jobs if table is empty
+    const [jobsResult] = await db.select({ count: jobs.id }).from(jobs);
+    const jobsCount = parseInt(jobsResult?.count as unknown as string, 10) || 0;
+    if (jobsCount === 0) {
       await this.initializeSampleJobs();
+    }
+
+    // Populate sample news if table is empty
+    const [newsResult] = await db.select({ count: news.id }).from(news);
+    const newsCount = parseInt(newsResult?.count as unknown as string, 10) || 0;
+    if (newsCount === 0) {
       await this.initializeSampleNews();
     }
   }


### PR DESCRIPTION
## Summary
- eliminate default admin from in-memory storage
- seed only content, jobs, and news when DB is empty
- document `ADMIN_USER`/`ADMIN_PASSWORD` environment variables

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_68406b1141d483309da11411a8c6bd53