### PR TITLE
Centralize heading styles

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -85,6 +85,30 @@
     @apply font-medium tracking-tight;
   }
 
+  h1 {
+    @apply text-5xl md:text-6xl;
+  }
+
+  h2 {
+    @apply text-4xl md:text-5xl;
+  }
+
+  h3 {
+    @apply text-3xl md:text-4xl;
+  }
+
+  h4 {
+    @apply text-2xl md:text-3xl;
+  }
+
+  h5 {
+    @apply text-xl md:text-2xl;
+  }
+
+  h6 {
+    @apply text-lg md:text-xl;
+  }
+
   /* Custom dot styling for "ness" logo */
   .ness-dot {
     @apply inline-block rounded-full;

--- a/client/src/site/forense/AboutPage.tsx
+++ b/client/src/site/forense/AboutPage.tsx
@@ -67,7 +67,7 @@ export default function ForenseAboutPage() {
         <section className="intro text-white bg-[#0d1117] relative overflow-hidden flex items-center" style={{ minHeight: "60vh" }}>
           <div className="container mx-auto px-4 relative z-10">
             <div className="max-w-3xl mx-auto text-center">
-              <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-6 lowercase">
+              <h1 className="mb-6 lowercase">
                 forense<span className="text-[#00ade0]">.</span>io
               </h1>
               <p className="text-xl text-gray-300 mb-8">
@@ -81,7 +81,7 @@ export default function ForenseAboutPage() {
         <section className="conteudo bg-white" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
             <div className="text-center mb-12">
-              <h2 className="text-3xl font-['Montserrat'] font-normal text-gray-800 mb-4 lowercase">
+              <h2 className="text-gray-800 mb-4 lowercase">
                 {language === 'pt' && <>sobre a forense<span className="text-[#00ade0]">.</span>io</>}
                 {language === 'en' && <>about forense<span className="text-[#00ade0]">.</span>io</>}
                 {language === 'es' && <>sobre forense<span className="text-[#00ade0]">.</span>io</>}
@@ -95,7 +95,7 @@ export default function ForenseAboutPage() {
             
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
               <div className="bg-[#0d1117] p-8 rounded-lg shadow-md">
-                <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-white lowercase">
+                <h3 className="mb-4 text-white lowercase">
                   {language === 'pt' && 'expertise forense'}
                   {language === 'en' && 'forensic expertise'}
                   {language === 'es' && 'experiencia forense'}
@@ -109,7 +109,7 @@ export default function ForenseAboutPage() {
               </div>
               
               <div className="bg-[#0d1117] p-8 rounded-lg shadow-md">
-                <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-white lowercase">
+                <h3 className="mb-4 text-white lowercase">
                   {language === 'pt' && 'tecnologia avançada'}
                   {language === 'en' && 'advanced technology'}
                   {language === 'es' && 'tecnología avanzada'}
@@ -123,7 +123,7 @@ export default function ForenseAboutPage() {
               </div>
               
               <div className="bg-[#0d1117] p-8 rounded-lg shadow-md">
-                <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-white lowercase">
+                <h3 className="mb-4 text-white lowercase">
                   {language === 'pt' && 'resultados concretos'}
                   {language === 'en' && 'concrete results'}
                   {language === 'es' && 'resultados concretos'}
@@ -142,12 +142,12 @@ export default function ForenseAboutPage() {
         {/* Values Section */}
         <section className="conteudo bg-gray-900 text-white" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-center mb-12 lowercase text-white">{defaultContent.values.title}</h2>
+            <h2 className="text-center mb-12 lowercase text-white">{defaultContent.values.title}</h2>
             
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
               {/* Vision */}
               <div className="bg-gray-800 p-8 rounded-sm border-l-2 border-[#00ade0]">
-                <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
+                <h3 className="mb-4 lowercase text-white">
                   {defaultContent.values.vision.title}
                 </h3>
                 <p className="text-gray-300 lowercase">
@@ -157,7 +157,7 @@ export default function ForenseAboutPage() {
               
               {/* Mission */}
               <div className="bg-gray-800 p-8 rounded-sm border-l-2 border-[#00ade0]">
-                <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
+                <h3 className="mb-4 lowercase text-white">
                   {defaultContent.values.mission.title}
                 </h3>
                 <p className="text-gray-300 lowercase">
@@ -171,7 +171,7 @@ export default function ForenseAboutPage() {
         {/* Timeline Section */}
         <section className="conteudo bg-gray-50" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-center mb-12 lowercase">
+            <h2 className="text-center mb-12 lowercase">
               {defaultContent.timeline}
             </h2>
             
@@ -185,7 +185,7 @@ export default function ForenseAboutPage() {
                   <div key={year} className={`flex mb-16 ${index % 2 === 0 ? 'flex-row' : 'flex-row-reverse'}`}>
                     <div className="w-1/2 px-6">
                       <div className={`${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
-                        <span className="text-2xl font-['Montserrat'] font-medium text-gray-900">
+                        <span className="text-gray-900 text-2xl font-medium">
                           {year.includes('.') ? year.split('.')[0] : year}
                           {year.includes('.') && <span className="text-[#00ade0] text-sm">.{year.split('.')[1]}</span>}
                         </span>
@@ -208,7 +208,7 @@ export default function ForenseAboutPage() {
         {/* CTA Section */}
         <section className="contato bg-[#0d1117] text-white flex items-center" style={{ minHeight: "400px" }}>
           <div className="container mx-auto px-4 text-center">
-            <h2 className="text-3xl font-['Montserrat'] font-normal mb-8 lowercase">
+            <h2 className="mb-8 lowercase">
               {language === 'pt' 
                 ? <>quer saber mais sobre a <span className="font-normal">forense<span className="text-[#00ade0]">.</span>io</span>?</> 
                 : language === 'en'

--- a/client/src/site/forense/HomePage.tsx
+++ b/client/src/site/forense/HomePage.tsx
@@ -43,10 +43,10 @@ export default function ForenseHomePage() {
       <section className="intro bg-[#0d1117] text-white relative overflow-hidden flex items-center" style={{ minHeight: "60vh" }}>
         <div className="container mx-auto px-4 relative">
           <div className="max-w-3xl mx-auto text-center">
-            <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-3 lowercase">
+            <h1 className="mb-3 lowercase">
               forense<span className="text-[#00ade0]">.</span>io
             </h1>
-            <h2 className="text-xl font-['Montserrat'] font-normal lowercase">
+            <h2 className="lowercase">
               {language === 'pt' && "Especialistas em Forense Digital"}
               {language === 'en' && "Digital Forensic Experts"}
               {language === 'es' && "Expertos en Forense Digital"}
@@ -73,7 +73,7 @@ export default function ForenseHomePage() {
       {/* Services Section */}
       <section id="services" className="conteudo bg-white" style={{ padding: "4rem 0" }}>
         <div className="container mx-auto px-4">
-          <h2 className="text-2xl font-['Montserrat'] font-normal text-center mb-16 lowercase">
+          <h2 className="text-center mb-16 lowercase">
             {language === 'pt' && <> serviços <span className="text-[#00ade0]">especializados</span></>}
             {language === 'en' && <> specialized <span className="text-[#00ade0]">services</span></>}
             {language === 'es' && <> servicios <span className="text-[#00ade0]">especializados</span></>}
@@ -83,7 +83,7 @@ export default function ForenseHomePage() {
             {/* Forense Digital */}
             <div className="bg-gray-50 p-6 rounded-lg border border-gray-100 hover:shadow-md transition-all duration-300 flex flex-col h-full">
               <div className="mb-4 text-center">
-                <h3 className="text-xl font-['Montserrat'] font-normal lowercase mb-1">
+                <h3 className="lowercase mb-1">
                   {language === 'pt' && "forense digital"}
                   {language === 'en' && "digital forensics"}
                   {language === 'es' && "forense digital"}
@@ -111,7 +111,7 @@ export default function ForenseHomePage() {
             {/* Suporte Legal */}
             <div className="bg-gray-50 p-6 rounded-lg border border-gray-100 hover:shadow-md transition-all duration-300 flex flex-col h-full">
               <div className="mb-4 text-center">
-                <h3 className="text-xl font-['Montserrat'] font-normal lowercase mb-1">
+                <h3 className="lowercase mb-1">
                   {language === 'pt' && "suporte legal"}
                   {language === 'en' && "legal support"}
                   {language === 'es' && "soporte legal"}
@@ -139,7 +139,7 @@ export default function ForenseHomePage() {
             {/* Investigações Corporativas */}
             <div className="bg-gray-50 p-6 rounded-lg border border-gray-100 hover:shadow-md transition-all duration-300 flex flex-col h-full">
               <div className="mb-4 text-center">
-                <h3 className="text-xl font-['Montserrat'] font-normal lowercase mb-1">
+                <h3 className="lowercase mb-1">
                   {language === 'pt' && "investigações corporativas"}
                   {language === 'en' && "corporate investigations"}
                   {language === 'es' && "investigaciones corporativas"}
@@ -171,7 +171,7 @@ export default function ForenseHomePage() {
       <section className="contato bg-[#0d1117] text-white flex items-center" style={{ minHeight: "400px" }}>
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
-            <h2 className="text-2xl font-['Montserrat'] font-normal mb-6 lowercase">
+            <h2 className="mb-6 lowercase">
               {language === 'pt' && <>precisando de <span className="text-[#00ade0]">consultoria especializada</span>?</>}
               {language === 'en' && <>need <span className="text-[#00ade0]">specialized consulting</span>?</>}
               {language === 'es' && <>¿necesita <span className="text-[#00ade0]">consultoría especializada</span>?</>}

--- a/client/src/site/layout/SiteNavbar.tsx
+++ b/client/src/site/layout/SiteNavbar.tsx
@@ -85,7 +85,7 @@ export default function SiteNavbar() {
           {/* Logo */}
           <div className="flex items-center">
             <Link href={sitePrefix} className="text-white lowercase">
-              <h1 className="font-['Montserrat'] font-normal text-3xl">
+              <h1 className="font-normal text-3xl">
                 {siteConfig.code === 'forense' 
                   ? <>forense<span style={{color: "#00ade0", marginLeft: "1px"}}>.</span>io</>
                   : <>{siteConfig.name.replace('.', '')}<span style={{color: "#00ade0", marginLeft: "1px"}}>.</span></>

--- a/client/src/site/ness/AboutPage.tsx
+++ b/client/src/site/ness/AboutPage.tsx
@@ -70,14 +70,14 @@ export default function NessAboutPage() {
           {/* Content */}
           <div className="container mx-auto px-4 z-10 flex justify-center items-center h-full">
             <div className="hero-main-content text-center max-w-4xl">
-              <h1 className="text-5xl md:text-6xl lg:text-7xl font-['Montserrat'] font-normal mb-6">
+              <h1 className="mb-6">
                 <span style={{color: "#ffffff"}}>ness</span><span style={{color: "#00ade0"}}>.</span>
               </h1>
-              <p className="text-2xl md:text-3xl lg:text-4xl font-['Montserrat'] font-normal mb-6 text-white lowercase tracking-tight">
+              <p className="text-2xl md:text-3xl lg:text-4xl font-normal mb-6 text-white lowercase tracking-tight">
                 {defaultContent.heroTitle}
               </p>
             
-              <p className="text-lg md:text-xl lg:text-2xl mb-8 mx-auto text-white font-['Montserrat'] lowercase font-light">
+              <p className="text-lg md:text-xl lg:text-2xl mb-8 mx-auto text-white lowercase font-light">
                 {defaultContent.heroSubtitle}
               </p>
             </div>
@@ -88,7 +88,7 @@ export default function NessAboutPage() {
         <section className="conteudo bg-gray-50" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
             <div className="max-w-3xl mx-auto">
-              <h2 className="font-['Montserrat'] font-normal text-2xl md:text-3xl mb-6 text-center lowercase">
+              <h2 className="mb-6 text-center lowercase">
                 <span className="font-normal">{language === 'pt' ? 'somos a' : language === 'es' ? 'somos' : 'we are'}</span> <span className="text-black font-normal">ness<span className="text-[#00ade0]">.</span></span>
               </h2>
               
@@ -127,12 +127,12 @@ export default function NessAboutPage() {
         {/* Values Section */}
         <section className="conteudo bg-[#2c2c34]" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-center mb-12 lowercase text-[#00ade0]">{defaultContent.values.title}</h2>
+            <h2 className="text-center mb-12 lowercase text-[#00ade0]">{defaultContent.values.title}</h2>
             
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               {/* Vision */}
               <div className="bg-[#38383f] p-8 rounded-sm border-l-2 border-[#00ade0]">
-                <h3 className="text-xl font-['Montserrat'] font-medium mb-4 lowercase text-white">
+                <h3 className="mb-4 lowercase text-white font-medium">
                   {defaultContent.values.vision.title}
                 </h3>
                 <p className="text-gray-200 lowercase">
@@ -142,7 +142,7 @@ export default function NessAboutPage() {
               
               {/* Mission */}
               <div className="bg-[#38383f] p-8 rounded-sm border-l-2 border-[#00ade0]">
-                <h3 className="text-xl font-['Montserrat'] font-medium mb-4 lowercase text-white">
+                <h3 className="mb-4 lowercase text-white font-medium">
                   {defaultContent.values.mission.title}
                 </h3>
                 <p className="text-gray-200 lowercase">
@@ -152,7 +152,7 @@ export default function NessAboutPage() {
               
               {/* Values */}
               <div className="bg-[#38383f] p-8 rounded-sm border-l-2 border-[#00ade0]">
-                <h3 className="text-xl font-['Montserrat'] font-medium mb-4 lowercase text-white">
+                <h3 className="mb-4 lowercase text-white font-medium">
                   {defaultContent.values.values.title}
                 </h3>
                 <p className="text-gray-200 lowercase mb-4">
@@ -169,7 +169,7 @@ export default function NessAboutPage() {
         {/* Timeline Section */}
         <section className="conteudo bg-gray-50" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-center mb-12 lowercase">{defaultContent.timeline}</h2>
+            <h2 className="text-center mb-12 lowercase">{defaultContent.timeline}</h2>
             
             <div className="max-w-5xl mx-auto">
               <div className="relative">
@@ -181,7 +181,7 @@ export default function NessAboutPage() {
                   <div key={year} className={`flex mb-16 ${index % 2 === 0 ? 'flex-row' : 'flex-row-reverse'}`}>
                     <div className="w-1/2 px-6">
                       <div className={`${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
-                        <span className="text-2xl font-['Montserrat'] font-medium text-gray-900">
+                        <span className="text-gray-900 text-2xl font-medium">
                           {year.includes('.') ? year.split('.')[0] : year}
                           {year.includes('.') && <span className="text-[#00ade0] text-sm">.{year.split('.')[1]}</span>}
                         </span>
@@ -204,7 +204,7 @@ export default function NessAboutPage() {
         {/* CTA Section */}
         <section className="contato bg-[#4d4d4d] text-white flex items-center" style={{ minHeight: "400px" }}>
           <div className="container mx-auto px-4 text-center">
-            <h2 className="text-3xl font-['Montserrat'] font-normal mb-8 lowercase">
+            <h2 className="mb-8 lowercase">
               {language === 'pt' 
                 ? <>quer saber mais sobre a <span className="font-normal">ness<span className="text-[#00ade0]">.</span></span>?</> 
                 : language === 'en'

--- a/client/src/site/ness/HomePage.backup.tsx
+++ b/client/src/site/ness/HomePage.backup.tsx
@@ -65,7 +65,7 @@ export default function NessHomePage() {
       <section className="conteudo bg-white" style={{ padding: "4rem 0" }}>
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-gray-800 mb-4 lowercase">
+            <h2 className="text-gray-800 mb-4 lowercase">
               {pageContent?.content && JSON.parse(pageContent.content).featuredSectionTitle || 'tecnologia modular para o essencial invisível'}
             </h2>
             <p className="text-gray-600 max-w-3xl mx-auto">

--- a/client/src/site/ness/HomePage.tsx
+++ b/client/src/site/ness/HomePage.tsx
@@ -89,7 +89,7 @@ export default function NessHomePage() {
       <section className="conteudo bg-white" style={{ padding: "4rem 0" }}>
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-gray-800 mb-4 lowercase">
+            <h2 className="text-gray-800 mb-4 lowercase">
               {pageContent?.content && JSON.parse(pageContent.content).featuredSectionTitle || 'tecnologia modular para o essencial invisível'}
             </h2>
             <p className="text-gray-600 max-w-3xl mx-auto">

--- a/client/src/site/trustness/AboutPage.tsx
+++ b/client/src/site/trustness/AboutPage.tsx
@@ -64,7 +64,7 @@ export default function TrustnessAboutPage() {
           
           <div className="container mx-auto px-4 relative z-10">
             <div className="max-w-3xl mx-auto text-center">
-              <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-6 lowercase">
+              <h1 className="mb-6 lowercase">
                 trustness<span className="text-[#005fa3]">.</span>
               </h1>
               <p className="text-xl text-gray-300 mb-8">
@@ -78,7 +78,7 @@ export default function TrustnessAboutPage() {
         <section className="conteudo bg-gray-50" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
             <div className="max-w-3xl mx-auto">
-              <h2 className="font-['Montserrat'] font-normal text-2xl md:text-3xl mb-6 text-center lowercase">
+              <h2 className="text-center mb-6 lowercase">
                 <span className="font-normal">
                   {language === 'pt' ? 'somos a' : language === 'es' ? 'somos' : 'we are'}
                 </span> <span className="text-black font-normal">trustness<span className="text-[#005fa3]">.</span></span>
@@ -112,12 +112,12 @@ export default function TrustnessAboutPage() {
         {/* Values Section */}
         <section className="conteudo bg-[#1a1a22] text-white" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-center mb-12 lowercase text-white">{defaultContent.values.title}</h2>
+            <h2 className="text-center mb-12 lowercase text-white">{defaultContent.values.title}</h2>
             
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               {/* Vision */}
               <div className="bg-[#21212b] p-8 rounded-sm border-l-2 border-[#005fa3]">
-                <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
+                <h3 className="mb-4 lowercase text-white">
                   {defaultContent.values.vision.title}
                 </h3>
                 <p className="text-gray-300 lowercase">
@@ -127,7 +127,7 @@ export default function TrustnessAboutPage() {
               
               {/* Mission */}
               <div className="bg-[#21212b] p-8 rounded-sm border-l-2 border-[#005fa3]">
-                <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
+                <h3 className="mb-4 lowercase text-white">
                   {defaultContent.values.mission.title}
                 </h3>
                 <p className="text-gray-300 lowercase">
@@ -137,7 +137,7 @@ export default function TrustnessAboutPage() {
               
               {/* Values */}
               <div className="bg-[#21212b] p-8 rounded-sm border-l-2 border-[#005fa3]">
-                <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
+                <h3 className="mb-4 lowercase text-white">
                   {defaultContent.values.values.title}
                 </h3>
                 <p className="text-gray-300 lowercase mb-3">
@@ -164,7 +164,7 @@ export default function TrustnessAboutPage() {
         {/* Timeline Section */}
         <section className="conteudo bg-gray-50" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-center mb-12 lowercase">
+            <h2 className="text-center mb-12 lowercase">
               {defaultContent.timeline}
             </h2>
             
@@ -178,7 +178,7 @@ export default function TrustnessAboutPage() {
                   <div key={year} className={`flex mb-16 ${index % 2 === 0 ? 'flex-row' : 'flex-row-reverse'}`}>
                     <div className="w-1/2 px-6">
                       <div className={`${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
-                        <span className="text-2xl font-['Montserrat'] font-medium text-gray-900">
+                        <span className="text-gray-900 text-2xl font-medium">
                           {year.includes('.') ? year.split('.')[0] : year}
                           {year.includes('.') && <span className="text-[#00ade0] text-sm">.{year.split('.')[1]}</span>}
                         </span>
@@ -201,7 +201,7 @@ export default function TrustnessAboutPage() {
         {/* CTA Section */}
         <section className="contato bg-[#1a1a22] text-white flex items-center" style={{ minHeight: "400px" }}>
           <div className="container mx-auto px-4 text-center">
-            <h2 className="text-3xl font-['Montserrat'] font-normal mb-8 lowercase">
+            <h2 className="mb-8 lowercase">
               {language === 'pt' 
                 ? <>quer saber mais sobre a <span className="font-normal">trustness<span className="text-[#00ade0]">.</span></span>?</> 
                 : language === 'en'

--- a/client/src/site/trustness/HomePage.tsx
+++ b/client/src/site/trustness/HomePage.tsx
@@ -47,7 +47,7 @@ export default function TrustnessHomePage() {
         
         <div className="container mx-auto px-4 relative z-10">
           <div className="max-w-3xl mx-auto text-center">
-            <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-6 lowercase">
+            <h1 className="mb-6 lowercase">
               trustness<span className="text-[#00ade0]">.</span>
             </h1>
             <p className="text-xl text-gray-300 mb-8">
@@ -84,7 +84,7 @@ export default function TrustnessHomePage() {
       <section className="conteudo bg-gradient-to-b from-white to-[#f2f8fd] text-gray-800" style={{ padding: "4rem 0" }}>
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-['Montserrat'] font-normal mb-4 lowercase text-gray-800">
+            <h2 className="mb-4 lowercase text-gray-800">
               {language === 'pt' && 'como atuamos'}
               {language === 'en' && 'how we work'}
               {language === 'es' && 'cómo trabajamos'}
@@ -101,7 +101,7 @@ export default function TrustnessHomePage() {
               <>
                 <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300">
                   <div className="mb-6">
-                    <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">assessment</h3>
+                    <h3 className="mb-4 text-gray-800">assessment</h3>
                   </div>
                   <p className="mb-4">
                     <span className="text-[#005fa3] font-semibold text-lg block mb-2">você sabe como vai sua segurança?</span>
@@ -116,7 +116,7 @@ export default function TrustnessHomePage() {
                 
                 <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300">
                   <div className="mb-6">
-                    <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">certificações</h3>
+                    <h3 className="mb-4 text-gray-800">certificações</h3>
                   </div>
                   <p className="mb-4">
                     <span className="text-[#005fa3] font-semibold text-lg block mb-2">vai se certificar ISO 27001, ou outra certificação?</span>
@@ -128,7 +128,7 @@ export default function TrustnessHomePage() {
                 
                 <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300 md:col-span-2">
                   <div className="mb-6">
-                    <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">privacidade</h3>
+                    <h3 className="mb-4 text-gray-800">privacidade</h3>
                   </div>
                   <p className="mb-4">
                     <span className="text-[#005fa3] font-semibold text-lg block mb-2">precisa se adequar à LGPD, ou outra norma de privacidade?</span>
@@ -150,7 +150,7 @@ export default function TrustnessHomePage() {
               <>
                 <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300">
                   <div className="mb-6">
-                    <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">assessment</h3>
+                    <h3 className="mb-4 text-gray-800">assessment</h3>
                   </div>
                   <p className="mb-4">
                     <span className="text-[#005fa3] font-semibold text-lg block mb-2">do you know how your security is doing?</span>
@@ -165,7 +165,7 @@ export default function TrustnessHomePage() {
                 
                 <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300">
                   <div className="mb-6">
-                    <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">certifications</h3>
+                    <h3 className="mb-4 text-gray-800">certifications</h3>
                   </div>
                   <p className="mb-4">
                     <span className="text-[#005fa3] font-semibold text-lg block mb-2">need ISO 27001 certification or other security standards?</span>
@@ -177,7 +177,7 @@ export default function TrustnessHomePage() {
                 
                 <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300 md:col-span-2">
                   <div className="mb-6">
-                    <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">privacy</h3>
+                    <h3 className="mb-4 text-gray-800">privacy</h3>
                   </div>
                   <p className="mb-4">
                     <span className="text-[#005fa3] font-semibold text-lg block mb-2">need to comply with GDPR, LGPD or other privacy laws?</span>
@@ -199,7 +199,7 @@ export default function TrustnessHomePage() {
               <>
                 <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300">
                   <div className="mb-6">
-                    <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">assessment</h3>
+                    <h3 className="mb-4 text-gray-800">assessment</h3>
                   </div>
                   <p className="mb-4">
                     <span className="text-[#005fa3] font-semibold text-lg block mb-2">¿sabes cómo va tu seguridad?</span>
@@ -214,7 +214,7 @@ export default function TrustnessHomePage() {
                 
                 <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300">
                   <div className="mb-6">
-                    <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">certificaciones</h3>
+                    <h3 className="mb-4 text-gray-800">certificaciones</h3>
                   </div>
                   <p className="mb-4">
                     <span className="text-[#005fa3] font-semibold text-lg block mb-2">¿necesita certificarse en ISO 27001 u otros estándares de seguridad?</span>
@@ -226,7 +226,7 @@ export default function TrustnessHomePage() {
                 
                 <div className="bg-white p-8 rounded-lg shadow-sm border border-gray-100 hover:shadow-md transition-all duration-300 md:col-span-2">
                   <div className="mb-6">
-                    <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">privacidad</h3>
+                    <h3 className="mb-4 text-gray-800">privacidad</h3>
                   </div>
                   <p className="mb-4">
                     <span className="text-[#005fa3] font-semibold text-lg block mb-2">¿necesita cumplir con GDPR, LGPD u otras leyes de privacidad?</span>
@@ -251,7 +251,7 @@ export default function TrustnessHomePage() {
       <section id="what-we-do" className="conteudo bg-[#1a1a22] text-white" style={{ padding: "4rem 0" }}>
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-white mb-8 lowercase">
+            <h2 className="text-white mb-8 lowercase">
               {language === 'pt' && 'o que fazemos'}
               {language === 'en' && 'what we do'}
               {language === 'es' && 'lo que hacemos'}
@@ -262,7 +262,7 @@ export default function TrustnessHomePage() {
             {/* Serviço 1 - Assessment */}
             <div className="bg-[#21212b] rounded p-6 border border-gray-800 shadow-sm hover:shadow-md transition-shadow duration-300 text-center">
               <h3 className="mb-4">
-                <span className="font-['Montserrat'] font-medium text-lg text-white">
+                <span className="font-medium text-lg text-white">
                   <span className="text-[#005fa3]">.</span>assessment
                 </span>
               </h3>
@@ -282,7 +282,7 @@ export default function TrustnessHomePage() {
             {/* Serviço 2 - Conformity */}
             <div className="bg-[#21212b] rounded p-6 border border-gray-800 shadow-sm hover:shadow-md transition-shadow duration-300 text-center">
               <h3 className="mb-4">
-                <span className="font-['Montserrat'] font-medium text-lg text-white">
+                <span className="font-medium text-lg text-white">
                   <span className="text-[#005fa3]">.</span>conformity
                 </span>
               </h3>
@@ -302,7 +302,7 @@ export default function TrustnessHomePage() {
             {/* Serviço 3 - Privacy */}
             <div className="bg-[#21212b] rounded p-6 border border-gray-800 shadow-sm hover:shadow-md transition-shadow duration-300 text-center">
               <h3 className="mb-4">
-                <span className="font-['Montserrat'] font-medium text-lg text-white">
+                <span className="font-medium text-lg text-white">
                   <span className="text-[#005fa3]">.</span>privacy
                 </span>
               </h3>
@@ -327,7 +327,7 @@ export default function TrustnessHomePage() {
         <section className="conteudo bg-gray-50" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
             <div className="text-center mb-16">
-              <h2 className="text-3xl font-['Montserrat'] font-normal text-gray-800 mb-4 lowercase">
+              <h2 className="text-gray-800 mb-4 lowercase">
                 {pageContent?.content?.clientsSectionTitle || 'clientes'}
               </h2>
               <p className="text-gray-600 max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- define responsive default sizes for headings in `@layer base`
- remove heading text size & font classes from pages
- rely on body styling for the Montserrat font

## Testing
- `npm run check` *(fails: Cannot find type definition file)*
- `npm run dev` *(fails: tsx not found)*


------
https://chatgpt.com/codex/tasks/task_b_68406b2061248330a9837fa1f5b6aada