### PR TITLE
refactor: centralize brand colors

### DIFF
--- a/client/src/components/common/LanguageSelector.tsx
+++ b/client/src/components/common/LanguageSelector.tsx
@@ -44,7 +44,7 @@ export default function LanguageSelector() {
         aria-expanded={isOpen}
         aria-haspopup="true"
       >
-        <svg className="w-4 h-4 mr-0.5 text-[#00ade0]" viewBox="0 0 24 24" fill="currentColor">
+        <svg className="w-4 h-4 mr-0.5 text-[var(--primary-color)]" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z" opacity="0.2" />
           <path d="M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12zm10-8a8 8 0 100 16 8 8 0 000-16z" strokeWidth="1" stroke="currentColor" fill="none" />
           <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z" fill="none" stroke="currentColor" strokeWidth="1" />
@@ -61,13 +61,13 @@ export default function LanguageSelector() {
       </button>
       
       {isOpen && (
-        <div className="absolute right-0 mt-1 w-32 bg-[#1b2838] rounded-md shadow-lg overflow-hidden z-50 border border-[#2f3e4d]">
+        <div className="absolute right-0 mt-1 w-32 bg-[#1b2838] rounded-md shadow-lg overflow-hidden z-50 border border-[var(--secondary-color)]">
           {languages.map((lang) => (
             <button
               key={lang.code}
               onClick={() => handleLanguageChange(lang.code)}
               className={`block w-full text-left px-3 py-1.5 text-xs ${
-                language === lang.code ? 'bg-[#2f3e4d] text-[#00ade0] font-medium' : 'text-gray-300 hover:bg-[#2f3e4d]'
+                language === lang.code ? 'bg-[var(--secondary-color)] text-[var(--primary-color)] font-medium' : 'text-gray-300 hover:bg-[var(--secondary-color)]'
               }`}
             >
               {lang.label}

--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -20,7 +20,7 @@ export default function Footer() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
           <div>
             <Link href="/" className="text-white text-xl mb-6 inline-block lowercase">
-              ness<span style={{color: "#00ade0", marginLeft: "1px"}}>.</span>
+              ness<span style={{color: "var(--primary-color)", marginLeft: "1px"}}>.</span>
             </Link>
             <p className="text-gray-300 mb-6">
               Desde 1991, fornecemos soluções empresariais de alta qualidade com foco em cibersegurança, infraestrutura e arquitetura de software.
@@ -85,7 +85,7 @@ export default function Footer() {
         </div>
         
         <div className="border-t border-gray-800 mt-12 pt-8 text-center text-gray-300">
-          <p>&copy; {currentYear} ness<span style={{color: "#00ade0", marginLeft: "1px"}}>.</span> {t('footer.rights')}.</p>
+          <p>&copy; {currentYear} ness<span style={{color: "var(--primary-color)", marginLeft: "1px"}}>.</span> {t('footer.rights')}.</p>
           <div className="mt-2">
             <Link href="/admin/login" className="text-gray-300 hover:text-accent transition duration-300">{t('nav.login')}</Link>
           </div>

--- a/client/src/components/layout/Navbar.tsx
+++ b/client/src/components/layout/Navbar.tsx
@@ -127,7 +127,7 @@ export default function Navbar() {
           <div className="flex items-center">
             <Link href="/" className="text-white lowercase">
               <h1 className="font-['Montserrat'] font-normal text-3xl">
-                ness<span style={{color: "#00ade0", marginLeft: "1px"}}>.</span>
+                ness<span style={{color: "var(--primary-color)", marginLeft: "1px"}}>.</span>
               </h1>
             </Link>
           </div>
@@ -167,7 +167,7 @@ export default function Navbar() {
                     >
                       <div className="p-3 rounded hover:bg-gray-50 transition-colors duration-200 border border-gray-100 h-full">
                         <h3 className="font-['Montserrat'] text-gray-800 text-lg mb-2">
-                          n<span className="text-[#00ade0]">.</span>SecOps
+                          n<span className="text-[var(--primary-color)]">.</span>SecOps
                         </h3>
                         <p className="text-sm text-gray-600 leading-snug">
                           {serviceDescriptions[language as keyof typeof serviceDescriptions].secops}
@@ -183,7 +183,7 @@ export default function Navbar() {
                     >
                       <div className="p-3 rounded hover:bg-gray-50 transition-colors duration-200 border border-gray-100 h-full">
                         <h3 className="font-['Montserrat'] text-gray-800 text-lg mb-2">
-                          n<span className="text-[#00ade0]">.</span>InfraOps
+                          n<span className="text-[var(--primary-color)]">.</span>InfraOps
                         </h3>
                         <p className="text-sm text-gray-600 leading-snug">
                           {serviceDescriptions[language as keyof typeof serviceDescriptions].infraops}
@@ -199,7 +199,7 @@ export default function Navbar() {
                     >
                       <div className="p-3 rounded hover:bg-gray-50 transition-colors duration-200 border border-gray-100 h-full">
                         <h3 className="font-['Montserrat'] text-gray-800 text-lg mb-2">
-                          n<span className="text-[#00ade0]">.</span>DevArch
+                          n<span className="text-[var(--primary-color)]">.</span>DevArch
                         </h3>
                         <p className="text-sm text-gray-600 leading-snug">
                           {serviceDescriptions[language as keyof typeof serviceDescriptions].devarch}
@@ -215,7 +215,7 @@ export default function Navbar() {
                     >
                       <div className="p-3 rounded hover:bg-gray-50 transition-colors duration-200 border border-gray-100 h-full">
                         <h3 className="font-['Montserrat'] text-gray-800 text-lg mb-2">
-                          n<span className="text-[#00ade0]">.</span>AutoOps
+                          n<span className="text-[var(--primary-color)]">.</span>AutoOps
                         </h3>
                         <p className="text-sm text-gray-600 leading-snug">
                           {serviceDescriptions[language as keyof typeof serviceDescriptions].autoops}
@@ -231,7 +231,7 @@ export default function Navbar() {
                     >
                       <div className="p-3 rounded hover:bg-gray-50 transition-colors duration-200 border border-gray-100 h-full">
                         <h3 className="font-['Montserrat'] text-gray-800 text-lg mb-2">
-                          n<span className="text-[#00ade0]">.</span>CrisisOps
+                          n<span className="text-[var(--primary-color)]">.</span>CrisisOps
                         </h3>
                         <p className="text-sm text-gray-600 leading-snug">
                           {serviceDescriptions[language as keyof typeof serviceDescriptions].crisisops}
@@ -247,7 +247,7 @@ export default function Navbar() {
                     >
                       <div className="p-3 rounded hover:bg-gray-50 transition-colors duration-200 border border-gray-100 h-full">
                         <h3 className="font-['Montserrat'] text-gray-800 text-lg mb-2">
-                          n<span className="text-[#00ade0]">.</span>Privacy
+                          n<span className="text-[var(--primary-color)]">.</span>Privacy
                         </h3>
                         <p className="text-sm text-gray-600 leading-snug">
                           {serviceDescriptions[language as keyof typeof serviceDescriptions].privacy}
@@ -279,7 +279,7 @@ export default function Navbar() {
             <LanguageSelector />
             
             {/* Contact as a button */}
-            <Link href="/contact" className="bg-[#00ade0] hover:bg-[#0095c4] text-white py-2 px-4 rounded-sm transition duration-200 lowercase">
+            <Link href="/contact" className="bg-[var(--primary-color)] hover:bg-[#0095c4] text-white py-2 px-4 rounded-sm transition duration-200 lowercase">
               {t('nav.contact')}
             </Link>
             
@@ -376,7 +376,7 @@ export default function Navbar() {
               </div>
               
               {/* Contact as a button */}
-              <Link href="/contact" className="bg-[#00ade0] hover:bg-[#0095c4] text-white py-2 px-4 rounded-sm transition duration-200 text-center lowercase">
+              <Link href="/contact" className="bg-[var(--primary-color)] hover:bg-[#0095c4] text-white py-2 px-4 rounded-sm transition duration-200 text-center lowercase">
                 {t('nav.contact')}
               </Link>
               

--- a/client/src/components/sections/HeroSection.tsx
+++ b/client/src/components/sections/HeroSection.tsx
@@ -37,7 +37,7 @@ export default function HeroSection({
       <div className="container mx-auto px-4 z-10 flex justify-center items-center h-full">
         <div className="hero-main-content text-center">
           <h1 className="text-5xl md:text-6xl lg:text-7xl font-['Montserrat'] font-normal mb-6">
-            <span style={{color: "#ffffff"}}>ness</span><span className="text-[#00ade0]">.</span>
+            <span style={{color: "#ffffff"}}>ness</span><span className="text-[var(--primary-color)]">.</span>
           </h1>
           <div className="text-2xl md:text-3xl lg:text-4xl font-['Montserrat'] font-normal mb-4 text-white lowercase">
             {title}
@@ -48,10 +48,10 @@ export default function HeroSection({
           </p>
           
           <div className="flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-6 mt-8">
-            <Link href={ctaUrl1} className="bg-[#00ade0] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 inline-block lowercase rounded-sm font-['Montserrat']">
+            <Link href={ctaUrl1} className="bg-[var(--primary-color)] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 inline-block lowercase rounded-sm font-['Montserrat']">
               {ctaText1}
             </Link>
-            <Link href={ctaUrl2} className="bg-transparent border border-[#00ade0] text-white hover:text-[#00ade0] py-3 px-8 font-normal transition duration-300 inline-block lowercase rounded-sm font-['Montserrat']">
+            <Link href={ctaUrl2} className="bg-transparent border border-[var(--primary-color)] text-white hover:text-[var(--primary-color)] py-3 px-8 font-normal transition duration-300 inline-block lowercase rounded-sm font-['Montserrat']">
               {ctaText2}
             </Link>
           </div>

--- a/client/src/components/sections/ServicesSection.tsx
+++ b/client/src/components/sections/ServicesSection.tsx
@@ -19,13 +19,13 @@ export default function ServicesSection({ title }: ServicesSectionProps) {
   const getTitleJSX = (language: string) => {
     switch (language) {
       case 'pt':
-        return <>serviços <span className="text-[#00ade0]">modulares</span></>;
+        return <>serviços <span className="text-[var(--primary-color)]">modulares</span></>;
       case 'en':
-        return <><span className="text-[#00ade0]">modular</span> services</>;
+        return <><span className="text-[var(--primary-color)]">modular</span> services</>;
       case 'es':
-        return <>servicios <span className="text-[#00ade0]">modulares</span></>;
+        return <>servicios <span className="text-[var(--primary-color)]">modulares</span></>;
       default:
-        return <>serviços <span className="text-[#00ade0]">modulares</span></>;
+        return <>serviços <span className="text-[var(--primary-color)]">modulares</span></>;
     }
   };
   
@@ -116,7 +116,7 @@ export default function ServicesSection({ title }: ServicesSectionProps) {
     if (name.startsWith('n.')) {
       return (
         <span className="font-['Montserrat'] font-medium text-lg text-gray-800">
-          n<span className="text-[#00ade0]">.</span>{name.substring(2)}
+          n<span className="text-[var(--primary-color)]">.</span>{name.substring(2)}
         </span>
       );
     }
@@ -147,7 +147,7 @@ export default function ServicesSection({ title }: ServicesSectionProps) {
               <div className="text-center">
                 <Link 
                   href={service.url} 
-                  className="text-gray-600 hover:text-[#00ade0] border border-gray-300 hover:border-[#00ade0] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
+                  className="text-gray-600 hover:text-[var(--primary-color)] border border-gray-300 hover:border-[var(--primary-color)] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
                 >
                   {buttonText[language]}
                 </Link>

--- a/client/src/components/sections/SpinoffsSection.tsx
+++ b/client/src/components/sections/SpinoffsSection.tsx
@@ -64,7 +64,7 @@ export default function SpinoffsSection({ title }: SpinoffsSectionProps) {
       return (
         <span className="font-['Montserrat'] font-medium text-xl">
           {parts[0]}
-          <span className="text-[#00ade0]">.</span>
+          <span className="text-[var(--primary-color)]">.</span>
           {parts.length > 1 ? parts[1] : ''}
         </span>
       );
@@ -73,7 +73,7 @@ export default function SpinoffsSection({ title }: SpinoffsSectionProps) {
   };
   
   return (
-    <section id="spinoffs" className="contato bg-[#2f3e4d] text-white flex items-center" style={{ minHeight: "400px" }}>
+    <section id="spinoffs" className="contato bg-[var(--secondary-color)] text-white flex items-center" style={{ minHeight: "400px" }}>
       <div className="container mx-auto px-4">
         <div className="text-center mb-16">
           <h2 className="text-3xl font-['Montserrat'] font-normal mb-8 lowercase">{title || titles[language]}</h2>
@@ -97,7 +97,7 @@ export default function SpinoffsSection({ title }: SpinoffsSectionProps) {
                     href={spinoff.url} 
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-white hover:text-[#00ade0] border border-white hover:border-[#00ade0] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-flex items-center lowercase rounded-sm"
+                    className="text-white hover:text-[var(--primary-color)] border border-white hover:border-[var(--primary-color)] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-flex items-center lowercase rounded-sm"
                   >
                     {buttonText[language]}
                     <ExternalLink className="ml-1 h-3 w-3" />
@@ -105,7 +105,7 @@ export default function SpinoffsSection({ title }: SpinoffsSectionProps) {
                 ) : (
                   <Link 
                     href={spinoff.url} 
-                    className="text-white hover:text-[#00ade0] border border-white hover:border-[#00ade0] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
+                    className="text-white hover:text-[var(--primary-color)] border border-white hover:border-[var(--primary-color)] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
                   >
                     {buttonText[language]}
                   </Link>

--- a/client/src/site/forense/AboutPage.tsx
+++ b/client/src/site/forense/AboutPage.tsx
@@ -68,7 +68,7 @@ export default function ForenseAboutPage() {
           <div className="container mx-auto px-4 relative z-10">
             <div className="max-w-3xl mx-auto text-center">
               <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-6 lowercase">
-                forense<span className="text-[#00ade0]">.</span>io
+                forense<span className="text-[var(--primary-color)]">.</span>io
               </h1>
               <p className="text-xl text-gray-300 mb-8">
                 {defaultContent.heroTitle}
@@ -82,9 +82,9 @@ export default function ForenseAboutPage() {
           <div className="container mx-auto px-4">
             <div className="text-center mb-12">
               <h2 className="text-3xl font-['Montserrat'] font-normal text-gray-800 mb-4 lowercase">
-                {language === 'pt' && <>sobre a forense<span className="text-[#00ade0]">.</span>io</>}
-                {language === 'en' && <>about forense<span className="text-[#00ade0]">.</span>io</>}
-                {language === 'es' && <>sobre forense<span className="text-[#00ade0]">.</span>io</>}
+                {language === 'pt' && <>sobre a forense<span className="text-[var(--primary-color)]">.</span>io</>}
+                {language === 'en' && <>about forense<span className="text-[var(--primary-color)]">.</span>io</>}
+                {language === 'es' && <>sobre forense<span className="text-[var(--primary-color)]">.</span>io</>}
               </h2>
               <p className="text-gray-600 max-w-3xl mx-auto mb-10">
                 {language === 'pt' && "convertemos complexidade técnica em resultados judiciais concretos"}
@@ -99,7 +99,7 @@ export default function ForenseAboutPage() {
                   {language === 'pt' && 'expertise forense'}
                   {language === 'en' && 'forensic expertise'}
                   {language === 'es' && 'experiencia forense'}
-                  <span className="text-[#00ade0]">.</span>
+                  <span className="text-[var(--primary-color)]">.</span>
                 </h3>
                 <p className="text-gray-300 text-sm mb-4">
                   {language === 'pt' && 'nossa equipe combina conhecimento técnico avançado com compreensão profunda dos requisitos legais, garantindo que cada evidência coletada seja juridicamente válida e tecnicamente robusta.'}
@@ -113,7 +113,7 @@ export default function ForenseAboutPage() {
                   {language === 'pt' && 'tecnologia avançada'}
                   {language === 'en' && 'advanced technology'}
                   {language === 'es' && 'tecnología avanzada'}
-                  <span className="text-[#00ade0]">.</span>
+                  <span className="text-[var(--primary-color)]">.</span>
                 </h3>
                 <p className="text-gray-300 text-sm mb-4">
                   {language === 'pt' && 'utilizamos ferramentas e metodologias proprietárias desenvolvidas ao longo de anos para recuperar, analisar e validar evidências digitais com o mais alto padrão de precisão do mercado.'}
@@ -127,7 +127,7 @@ export default function ForenseAboutPage() {
                   {language === 'pt' && 'resultados concretos'}
                   {language === 'en' && 'concrete results'}
                   {language === 'es' && 'resultados concretos'}
-                  <span className="text-[#00ade0]">.</span>
+                  <span className="text-[var(--primary-color)]">.</span>
                 </h3>
                 <p className="text-gray-300 text-sm mb-4">
                   {language === 'pt' && 'nosso trabalho vai além da simples coleta de dados - transformamos evidências técnicas em narrativas claras e defensáveis que sustentam decisões judiciais e corporativas.'}
@@ -146,7 +146,7 @@ export default function ForenseAboutPage() {
             
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
               {/* Vision */}
-              <div className="bg-gray-800 p-8 rounded-sm border-l-2 border-[#00ade0]">
+              <div className="bg-gray-800 p-8 rounded-sm border-l-2 border-[var(--primary-color)]">
                 <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
                   {defaultContent.values.vision.title}
                 </h3>
@@ -156,7 +156,7 @@ export default function ForenseAboutPage() {
               </div>
               
               {/* Mission */}
-              <div className="bg-gray-800 p-8 rounded-sm border-l-2 border-[#00ade0]">
+              <div className="bg-gray-800 p-8 rounded-sm border-l-2 border-[var(--primary-color)]">
                 <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
                   {defaultContent.values.mission.title}
                 </h3>
@@ -178,7 +178,7 @@ export default function ForenseAboutPage() {
             <div className="max-w-5xl mx-auto">
               <div className="relative">
                 {/* Linha do tempo vertical */}
-                <div className="absolute left-1/2 transform -translate-x-1/2 h-full w-px bg-[#00ade0] opacity-50"></div>
+                <div className="absolute left-1/2 transform -translate-x-1/2 h-full w-px bg-[var(--primary-color)] opacity-50"></div>
                 
                 {/* Eventos na linha do tempo */}
                 {Object.entries(defaultContent.timelineEvents).map(([year, description], index) => (
@@ -187,7 +187,7 @@ export default function ForenseAboutPage() {
                       <div className={`${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
                         <span className="text-2xl font-['Montserrat'] font-medium text-gray-900">
                           {year.includes('.') ? year.split('.')[0] : year}
-                          {year.includes('.') && <span className="text-[#00ade0] text-sm">.{year.split('.')[1]}</span>}
+                          {year.includes('.') && <span className="text-[var(--primary-color)] text-sm">.{year.split('.')[1]}</span>}
                         </span>
                         <p className="mt-2 text-gray-700 lowercase">
                           {description}
@@ -195,7 +195,7 @@ export default function ForenseAboutPage() {
                       </div>
                     </div>
                     
-                    <div className="absolute left-1/2 transform -translate-x-1/2 w-4 h-4 bg-[#00ade0] rounded-full mt-1"></div>
+                    <div className="absolute left-1/2 transform -translate-x-1/2 w-4 h-4 bg-[var(--primary-color)] rounded-full mt-1"></div>
                     
                     <div className="w-1/2 px-6"></div>
                   </div>
@@ -210,15 +210,15 @@ export default function ForenseAboutPage() {
           <div className="container mx-auto px-4 text-center">
             <h2 className="text-3xl font-['Montserrat'] font-normal mb-8 lowercase">
               {language === 'pt' 
-                ? <>quer saber mais sobre a <span className="font-normal">forense<span className="text-[#00ade0]">.</span>io</span>?</> 
+                ? <>quer saber mais sobre a <span className="font-normal">forense<span className="text-[var(--primary-color)]">.</span>io</span>?</> 
                 : language === 'en'
-                  ? <>want to know more about <span className="font-normal">forense<span className="text-[#00ade0]">.</span>io</span>?</>
-                  : <>¿quieres saber más sobre <span className="font-normal">forense<span className="text-[#00ade0]">.</span>io</span>?</>
+                  ? <>want to know more about <span className="font-normal">forense<span className="text-[var(--primary-color)]">.</span>io</span>?</>
+                  : <>¿quieres saber más sobre <span className="font-normal">forense<span className="text-[var(--primary-color)]">.</span>io</span>?</>
               }
             </h2>
             <a
               href={`/site/forense/contact`}
-              className="inline-block bg-[#00ade0] hover:bg-opacity-90 text-white py-3 px-8 rounded lowercase transition duration-300"
+              className="inline-block bg-[var(--primary-color)] hover:bg-opacity-90 text-white py-3 px-8 rounded lowercase transition duration-300"
             >
               {defaultContent.cta.button}
             </a>
@@ -232,7 +232,7 @@ export default function ForenseAboutPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center py-20">
-          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );

--- a/client/src/site/forense/HomePage.tsx
+++ b/client/src/site/forense/HomePage.tsx
@@ -44,7 +44,7 @@ export default function ForenseHomePage() {
         <div className="container mx-auto px-4 relative">
           <div className="max-w-3xl mx-auto text-center">
             <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-3 lowercase">
-              forense<span className="text-[#00ade0]">.</span>io
+              forense<span className="text-[var(--primary-color)]">.</span>io
             </h1>
             <h2 className="text-xl font-['Montserrat'] font-normal lowercase">
               {language === 'pt' && "Especialistas em Forense Digital"}
@@ -59,7 +59,7 @@ export default function ForenseHomePage() {
             <div className="flex justify-center">
               <a
                 href="/site/forense/contact"
-                className="bg-[#00ade0] hover:bg-opacity-90 text-white px-8 py-3 rounded lowercase transition-all duration-300"
+                className="bg-[var(--primary-color)] hover:bg-opacity-90 text-white px-8 py-3 rounded lowercase transition-all duration-300"
               >
                 {language === 'pt' && "fale conosco"}
                 {language === 'en' && "contact us"}
@@ -74,9 +74,9 @@ export default function ForenseHomePage() {
       <section id="services" className="conteudo bg-white" style={{ padding: "4rem 0" }}>
         <div className="container mx-auto px-4">
           <h2 className="text-2xl font-['Montserrat'] font-normal text-center mb-16 lowercase">
-            {language === 'pt' && <> serviços <span className="text-[#00ade0]">especializados</span></>}
-            {language === 'en' && <> specialized <span className="text-[#00ade0]">services</span></>}
-            {language === 'es' && <> servicios <span className="text-[#00ade0]">especializados</span></>}
+            {language === 'pt' && <> serviços <span className="text-[var(--primary-color)]">especializados</span></>}
+            {language === 'en' && <> specialized <span className="text-[var(--primary-color)]">services</span></>}
+            {language === 'es' && <> servicios <span className="text-[var(--primary-color)]">especializados</span></>}
           </h2>
           
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
@@ -100,7 +100,7 @@ export default function ForenseHomePage() {
                 {language === 'es' && "recuperación y análisis de datos digitales, producción y validación de evidencias, revisión forense y contraprueba de informes"}
               </p>
               <div className="mt-auto text-center">
-                <a href="/site/forense/services/digital-forensics" className="bg-white border border-[#00ade0] text-[#00ade0] hover:bg-[#00ade0] hover:text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-300 inline-flex justify-center">
+                <a href="/site/forense/services/digital-forensics" className="bg-white border border-[var(--primary-color)] text-[var(--primary-color)] hover:bg-[var(--primary-color)] hover:text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-300 inline-flex justify-center">
                   {language === 'pt' && "saiba mais"}
                   {language === 'en' && "learn more"}
                   {language === 'es' && "conocer más"}
@@ -128,7 +128,7 @@ export default function ForenseHomePage() {
                 {language === 'es' && "consultoría estratégica, asistencia técnica procesal y aclaraciones técnicas en audiencias para profesionales del área jurídica"}
               </p>
               <div className="mt-auto text-center">
-                <a href="/site/forense/services/legal-support" className="bg-white border border-[#00ade0] text-[#00ade0] hover:bg-[#00ade0] hover:text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-300 inline-flex justify-center">
+                <a href="/site/forense/services/legal-support" className="bg-white border border-[var(--primary-color)] text-[var(--primary-color)] hover:bg-[var(--primary-color)] hover:text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-300 inline-flex justify-center">
                   {language === 'pt' && "saiba mais"}
                   {language === 'en' && "learn more"}
                   {language === 'es' && "conocer más"}
@@ -156,7 +156,7 @@ export default function ForenseHomePage() {
                 {language === 'es' && "investigaciones de fraude, monitoreo de activos digitales, análisis de riesgos y amenazas, y compliance digital para empresas"}
               </p>
               <div className="mt-auto text-center">
-                <a href="/site/forense/services/corporate-investigations" className="bg-white border border-[#00ade0] text-[#00ade0] hover:bg-[#00ade0] hover:text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-300 inline-flex justify-center">
+                <a href="/site/forense/services/corporate-investigations" className="bg-white border border-[var(--primary-color)] text-[var(--primary-color)] hover:bg-[var(--primary-color)] hover:text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-300 inline-flex justify-center">
                   {language === 'pt' && "saiba mais"}
                   {language === 'en' && "learn more"}
                   {language === 'es' && "conocer más"}
@@ -172,9 +172,9 @@ export default function ForenseHomePage() {
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto text-center">
             <h2 className="text-2xl font-['Montserrat'] font-normal mb-6 lowercase">
-              {language === 'pt' && <>precisando de <span className="text-[#00ade0]">consultoria especializada</span>?</>}
-              {language === 'en' && <>need <span className="text-[#00ade0]">specialized consulting</span>?</>}
-              {language === 'es' && <>¿necesita <span className="text-[#00ade0]">consultoría especializada</span>?</>}
+              {language === 'pt' && <>precisando de <span className="text-[var(--primary-color)]">consultoria especializada</span>?</>}
+              {language === 'en' && <>need <span className="text-[var(--primary-color)]">specialized consulting</span>?</>}
+              {language === 'es' && <>¿necesita <span className="text-[var(--primary-color)]">consultoría especializada</span>?</>}
             </h2>
             <p className="text-gray-300 mb-10">
               {language === 'pt' && "Entre em contato para uma consulta inicial. Nossa equipe de especialistas está pronta para analisar seu caso e oferecer soluções personalizadas."}
@@ -183,7 +183,7 @@ export default function ForenseHomePage() {
             </p>
             <a
               href="/site/forense/contact"
-              className="bg-[#00ade0] hover:bg-opacity-90 text-white px-10 py-4 rounded lowercase transition-all duration-300 inline-block"
+              className="bg-[var(--primary-color)] hover:bg-opacity-90 text-white px-10 py-4 rounded lowercase transition-all duration-300 inline-block"
             >
               {language === 'pt' && "agende uma consulta"}
               {language === 'en' && "schedule a consultation"}

--- a/client/src/site/forense/services/CorporateInvestigationsPage.tsx
+++ b/client/src/site/forense/services/CorporateInvestigationsPage.tsx
@@ -7,7 +7,7 @@ import { forenseStyles as styles } from '../styles';
 import { defaultContent as translations } from '../translations/services/corporate-investigations';
 
 export default function ForenseCorporateInvestigationsPage() {
-  const DotSpan = () => <span className="text-[#00ade0]">.</span>;
+  const DotSpan = () => <span className="text-[var(--primary-color)]">.</span>;
   const { siteConfig } = useSite();
   const { language, t } = useI18n();
   
@@ -55,7 +55,7 @@ export default function ForenseCorporateInvestigationsPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center min-h-screen">
-          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );
@@ -100,9 +100,9 @@ export default function ForenseCorporateInvestigationsPage() {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                   <div>
                     <h3 className="text-xl font-['Montserrat'] font-normal text-gray-800 mb-4 lowercase">
-                      {language === 'pt' && (<><span className="text-[#00ade0]">discreta</span> e precisa</>)}
-                      {language === 'en' && (<><span className="text-[#00ade0]">discreet</span> and precise</>)}
-                      {language === 'es' && (<><span className="text-[#00ade0]">discreta</span> y precisa</>)}
+                      {language === 'pt' && (<><span className="text-[var(--primary-color)]">discreta</span> e precisa</>)}
+                      {language === 'en' && (<><span className="text-[var(--primary-color)]">discreet</span> and precise</>)}
+                      {language === 'es' && (<><span className="text-[var(--primary-color)]">discreta</span> y precisa</>)}
                     </h3>
                     <p className="text-gray-600 text-sm mb-6">
                       {language === 'pt' && 'nossas investigações são conduzidas com máxima discrição e precisão técnica, minimizando impactos nas operações diárias e preservando a confidencialidade em todas as etapas do processo.'}
@@ -118,13 +118,13 @@ export default function ForenseCorporateInvestigationsPage() {
                   
                   <div className="border-l border-gray-200 pl-8">
                     <h3 className="text-xl font-['Montserrat'] font-normal text-gray-800 mb-4 lowercase">
-                      {language === 'pt' && <>benefícios <span className="text-[#00ade0]">estratégicos</span></>}
-                      {language === 'en' && <>strategic <span className="text-[#00ade0]">benefits</span></>}
-                      {language === 'es' && <>beneficios <span className="text-[#00ade0]">estratégicos</span></>}
+                      {language === 'pt' && <>benefícios <span className="text-[var(--primary-color)]">estratégicos</span></>}
+                      {language === 'en' && <>strategic <span className="text-[var(--primary-color)]">benefits</span></>}
+                      {language === 'es' && <>beneficios <span className="text-[var(--primary-color)]">estratégicos</span></>}
                     </h3>
                     <ul className="space-y-3">
                       <li className="flex items-start">
-                        <div className="h-1.5 w-1.5 rounded-full bg-[#00ade0] mt-1.5 mr-2 flex-shrink-0"></div>
+                        <div className="h-1.5 w-1.5 rounded-full bg-[var(--primary-color)] mt-1.5 mr-2 flex-shrink-0"></div>
                         <span className="text-gray-600 text-sm">
                           {language === 'pt' && 'identificação precisa de incidentes e violações de políticas internas'}
                           {language === 'en' && 'precise identification of incidents and violations of internal policies'}
@@ -132,7 +132,7 @@ export default function ForenseCorporateInvestigationsPage() {
                         </span>
                       </li>
                       <li className="flex items-start">
-                        <div className="h-1.5 w-1.5 rounded-full bg-[#00ade0] mt-1.5 mr-2 flex-shrink-0"></div>
+                        <div className="h-1.5 w-1.5 rounded-full bg-[var(--primary-color)] mt-1.5 mr-2 flex-shrink-0"></div>
                         <span className="text-gray-600 text-sm">
                           {language === 'pt' && 'preservação adequada de evidências para processos disciplinares ou judiciais'}
                           {language === 'en' && 'proper preservation of evidence for disciplinary or judicial proceedings'}
@@ -140,7 +140,7 @@ export default function ForenseCorporateInvestigationsPage() {
                         </span>
                       </li>
                       <li className="flex items-start">
-                        <div className="h-1.5 w-1.5 rounded-full bg-[#00ade0] mt-1.5 mr-2 flex-shrink-0"></div>
+                        <div className="h-1.5 w-1.5 rounded-full bg-[var(--primary-color)] mt-1.5 mr-2 flex-shrink-0"></div>
                         <span className="text-gray-600 text-sm">
                           {language === 'pt' && 'recuperação de dados deletados ou ocultos relevantes para investigações internas'}
                           {language === 'en' && 'recovery of deleted or hidden data relevant to internal investigations'}
@@ -148,7 +148,7 @@ export default function ForenseCorporateInvestigationsPage() {
                         </span>
                       </li>
                       <li className="flex items-start">
-                        <div className="h-1.5 w-1.5 rounded-full bg-[#00ade0] mt-1.5 mr-2 flex-shrink-0"></div>
+                        <div className="h-1.5 w-1.5 rounded-full bg-[var(--primary-color)] mt-1.5 mr-2 flex-shrink-0"></div>
                         <span className="text-gray-600 text-sm">
                           {language === 'pt' && 'relatórios técnicos detalhados com linguagem acessível para tomada de decisão'}
                           {language === 'en' && 'detailed technical reports with accessible language for decision making'}
@@ -168,9 +168,9 @@ export default function ForenseCorporateInvestigationsPage() {
           <div className="container mx-auto px-4">
             <div className="max-w-6xl mx-auto">
               <h2 className="text-2xl font-['Montserrat'] font-normal text-gray-800 mb-16 text-center lowercase">
-                {language === 'pt' && <>serviços de <span className="text-[#00ade0]">investigação</span></>}
-                {language === 'en' && <>investigation <span className="text-[#00ade0]">services</span></>}
-                {language === 'es' && <>servicios de <span className="text-[#00ade0]">investigación</span></>}
+                {language === 'pt' && <>serviços de <span className="text-[var(--primary-color)]">investigação</span></>}
+                {language === 'en' && <>investigation <span className="text-[var(--primary-color)]">services</span></>}
+                {language === 'es' && <>servicios de <span className="text-[var(--primary-color)]">investigación</span></>}
               </h2>
               <div className="max-w-3xl mx-auto text-center mb-10">
                 <p className="text-gray-500 text-sm">
@@ -182,12 +182,12 @@ export default function ForenseCorporateInvestigationsPage() {
               
               <div className="grid grid-cols-1 md:grid-cols-3 gap-10">
                 {/* Investigação de Incidentes */}
-                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[#00ade0]/30">
+                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[var(--primary-color)]/30">
                   <div className="p-8">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase">
-                      {language === 'pt' && <>investigação de <span className="text-[#00ade0]">incidentes</span></>}
-                      {language === 'en' && <>incident <span className="text-[#00ade0]">investigation</span></>}
-                      {language === 'es' && <>investigación de <span className="text-[#00ade0]">incidentes</span></>}
+                      {language === 'pt' && <>investigação de <span className="text-[var(--primary-color)]">incidentes</span></>}
+                      {language === 'en' && <>incident <span className="text-[var(--primary-color)]">investigation</span></>}
+                      {language === 'es' && <>investigación de <span className="text-[var(--primary-color)]">incidentes</span></>}
                     </h3>
                     <p className="text-gray-600 mb-6 leading-relaxed">
                       {content.sections[0].content}
@@ -217,12 +217,12 @@ export default function ForenseCorporateInvestigationsPage() {
                 </div>
                 
                 {/* Auditoria Digital */}
-                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[#00ade0]/30">
+                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[var(--primary-color)]/30">
                   <div className="p-8">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase">
-                      {language === 'pt' && <>auditoria <span className="text-[#00ade0]">digital</span></>}
-                      {language === 'en' && <>digital <span className="text-[#00ade0]">audit</span></>}
-                      {language === 'es' && <>auditoría <span className="text-[#00ade0]">digital</span></>}
+                      {language === 'pt' && <>auditoria <span className="text-[var(--primary-color)]">digital</span></>}
+                      {language === 'en' && <>digital <span className="text-[var(--primary-color)]">audit</span></>}
+                      {language === 'es' && <>auditoría <span className="text-[var(--primary-color)]">digital</span></>}
                     </h3>
                     <p className="text-gray-600 mb-6 leading-relaxed">
                       {content.sections[1].content}
@@ -252,12 +252,12 @@ export default function ForenseCorporateInvestigationsPage() {
                 </div>
                 
                 {/* Perícia Computacional */}
-                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[#00ade0]/30">
+                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[var(--primary-color)]/30">
                   <div className="p-8">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase">
-                      {language === 'pt' && <>perícia <span className="text-[#00ade0]">computacional</span></>}
-                      {language === 'en' && <>computer <span className="text-[#00ade0]">forensics</span></>}
-                      {language === 'es' && <>peritaje <span className="text-[#00ade0]">computacional</span></>}
+                      {language === 'pt' && <>perícia <span className="text-[var(--primary-color)]">computacional</span></>}
+                      {language === 'en' && <>computer <span className="text-[var(--primary-color)]">forensics</span></>}
+                      {language === 'es' && <>peritaje <span className="text-[var(--primary-color)]">computacional</span></>}
                     </h3>
                     <p className="text-gray-600 mb-6 leading-relaxed">
                       {content.sections[2].content}
@@ -295,21 +295,21 @@ export default function ForenseCorporateInvestigationsPage() {
           <div className="container mx-auto px-4">
             <div className="max-w-5xl mx-auto">
               <h2 className="text-2xl font-['Montserrat'] font-normal mb-16 text-center lowercase">
-                {language === 'pt' && <>nossa <span className="text-[#00ade0]">metodologia</span></>}
-                {language === 'en' && <>our <span className="text-[#00ade0]">methodology</span></>}
-                {language === 'es' && <>nuestra <span className="text-[#00ade0]">metodología</span></>}
+                {language === 'pt' && <>nossa <span className="text-[var(--primary-color)]">metodologia</span></>}
+                {language === 'en' && <>our <span className="text-[var(--primary-color)]">methodology</span></>}
+                {language === 'es' && <>nuestra <span className="text-[var(--primary-color)]">metodología</span></>}
               </h2>
               
               <div className="grid grid-cols-1 md:grid-cols-2 gap-x-12 gap-y-16">
                 <div className="relative pl-10 md:pl-0">
-                  <div className="absolute left-0 top-0 flex items-center justify-center h-8 w-8 rounded-full bg-[#00ade0]/10 text-[#00ade0]">
+                  <div className="absolute left-0 top-0 flex items-center justify-center h-8 w-8 rounded-full bg-[var(--primary-color)]/10 text-[var(--primary-color)]">
                     <span className="text-xl font-light">1</span>
                   </div>
                   <div className="mb-4">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-3 lowercase">
-                      {language === 'pt' && <>avaliação <span className="text-[#00ade0]">inicial</span></>}
-                      {language === 'en' && <>initial <span className="text-[#00ade0]">assessment</span></>}
-                      {language === 'es' && <>evaluación <span className="text-[#00ade0]">inicial</span></>}
+                      {language === 'pt' && <>avaliação <span className="text-[var(--primary-color)]">inicial</span></>}
+                      {language === 'en' && <>initial <span className="text-[var(--primary-color)]">assessment</span></>}
+                      {language === 'es' && <>evaluación <span className="text-[var(--primary-color)]">inicial</span></>}
                     </h3>
                   </div>
                   <p className="text-gray-400 text-sm">
@@ -320,14 +320,14 @@ export default function ForenseCorporateInvestigationsPage() {
                 </div>
                 
                 <div className="relative pl-10 md:pl-0">
-                  <div className="absolute left-0 top-0 flex items-center justify-center h-8 w-8 rounded-full bg-[#00ade0]/10 text-[#00ade0]">
+                  <div className="absolute left-0 top-0 flex items-center justify-center h-8 w-8 rounded-full bg-[var(--primary-color)]/10 text-[var(--primary-color)]">
                     <span className="text-xl font-light">2</span>
                   </div>
                   <div className="mb-4">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-3 lowercase">
-                      {language === 'pt' && <>coleta <span className="text-[#00ade0]">forense</span></>}
-                      {language === 'en' && <>forensic <span className="text-[#00ade0]">collection</span></>}
-                      {language === 'es' && <>recolección <span className="text-[#00ade0]">forense</span></>}
+                      {language === 'pt' && <>coleta <span className="text-[var(--primary-color)]">forense</span></>}
+                      {language === 'en' && <>forensic <span className="text-[var(--primary-color)]">collection</span></>}
+                      {language === 'es' && <>recolección <span className="text-[var(--primary-color)]">forense</span></>}
                     </h3>
                   </div>
                   <p className="text-gray-400 text-sm">
@@ -338,14 +338,14 @@ export default function ForenseCorporateInvestigationsPage() {
                 </div>
                 
                 <div className="relative pl-10 md:pl-0">
-                  <div className="absolute left-0 top-0 flex items-center justify-center h-8 w-8 rounded-full bg-[#00ade0]/10 text-[#00ade0]">
+                  <div className="absolute left-0 top-0 flex items-center justify-center h-8 w-8 rounded-full bg-[var(--primary-color)]/10 text-[var(--primary-color)]">
                     <span className="text-xl font-light">3</span>
                   </div>
                   <div className="mb-4">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-3 lowercase">
-                      {language === 'pt' && <>análise <span className="text-[#00ade0]">técnica</span></>}
-                      {language === 'en' && <>technical <span className="text-[#00ade0]">analysis</span></>}
-                      {language === 'es' && <>análisis <span className="text-[#00ade0]">técnico</span></>}
+                      {language === 'pt' && <>análise <span className="text-[var(--primary-color)]">técnica</span></>}
+                      {language === 'en' && <>technical <span className="text-[var(--primary-color)]">analysis</span></>}
+                      {language === 'es' && <>análisis <span className="text-[var(--primary-color)]">técnico</span></>}
                     </h3>
                   </div>
                   <p className="text-gray-400 text-sm">
@@ -356,14 +356,14 @@ export default function ForenseCorporateInvestigationsPage() {
                 </div>
                 
                 <div className="relative pl-10 md:pl-0">
-                  <div className="absolute left-0 top-0 flex items-center justify-center h-8 w-8 rounded-full bg-[#00ade0]/10 text-[#00ade0]">
+                  <div className="absolute left-0 top-0 flex items-center justify-center h-8 w-8 rounded-full bg-[var(--primary-color)]/10 text-[var(--primary-color)]">
                     <span className="text-xl font-light">4</span>
                   </div>
                   <div className="mb-4">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-3 lowercase">
-                      {language === 'pt' && <>documentação <span className="text-[#00ade0]">e relatório</span></>}
-                      {language === 'en' && <>documentation <span className="text-[#00ade0]">and reporting</span></>}
-                      {language === 'es' && <>documentación <span className="text-[#00ade0]">e informe</span></>}
+                      {language === 'pt' && <>documentação <span className="text-[var(--primary-color)]">e relatório</span></>}
+                      {language === 'en' && <>documentation <span className="text-[var(--primary-color)]">and reporting</span></>}
+                      {language === 'es' && <>documentación <span className="text-[var(--primary-color)]">e informe</span></>}
                     </h3>
                   </div>
                   <p className="text-gray-400 text-sm">
@@ -382,17 +382,17 @@ export default function ForenseCorporateInvestigationsPage() {
           <div className="container mx-auto px-4">
             <div className="max-w-5xl mx-auto">
               <h2 className="text-2xl font-['Montserrat'] font-normal mb-16 text-center lowercase">
-                {language === 'pt' && <>casos de <span className="text-[#00ade0]">uso</span></>}
-                {language === 'en' && <>use <span className="text-[#00ade0]">cases</span></>}
-                {language === 'es' && <>casos de <span className="text-[#00ade0]">uso</span></>}
+                {language === 'pt' && <>casos de <span className="text-[var(--primary-color)]">uso</span></>}
+                {language === 'en' && <>use <span className="text-[var(--primary-color)]">cases</span></>}
+                {language === 'es' && <>casos de <span className="text-[var(--primary-color)]">uso</span></>}
               </h2>
               
               <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
                 <div className="bg-gray-50 rounded-lg p-8 border border-gray-100">
                   <h3 className="text-lg font-['Montserrat'] font-medium mb-4 text-gray-800 lowercase">
-                    {language === 'pt' && <>suspeita de <span className="text-[#00ade0]">fraude interna</span></>}
-                    {language === 'en' && <>suspected <span className="text-[#00ade0]">internal fraud</span></>}
-                    {language === 'es' && <>sospecha de <span className="text-[#00ade0]">fraude interno</span></>}
+                    {language === 'pt' && <>suspeita de <span className="text-[var(--primary-color)]">fraude interna</span></>}
+                    {language === 'en' && <>suspected <span className="text-[var(--primary-color)]">internal fraud</span></>}
+                    {language === 'es' && <>sospecha de <span className="text-[var(--primary-color)]">fraude interno</span></>}
                   </h3>
                   <p className="text-gray-600 text-sm">
                     {language === 'pt' && 'investigação de atividades suspeitas de funcionários, como desvio de recursos, manipulação de dados ou uso indevido de informações corporativas, usando técnicas forenses para recuperar e analisar evidências digitais.'}
@@ -403,9 +403,9 @@ export default function ForenseCorporateInvestigationsPage() {
                 
                 <div className="bg-gray-50 rounded-lg p-8 border border-gray-100">
                   <h3 className="text-lg font-['Montserrat'] font-medium mb-4 text-gray-800 lowercase">
-                    {language === 'pt' && <>vazamento de <span className="text-[#00ade0]">informações</span></>}
-                    {language === 'en' && <>information <span className="text-[#00ade0]">leak</span></>}
-                    {language === 'es' && <>filtración de <span className="text-[#00ade0]">información</span></>}
+                    {language === 'pt' && <>vazamento de <span className="text-[var(--primary-color)]">informações</span></>}
+                    {language === 'en' && <>information <span className="text-[var(--primary-color)]">leak</span></>}
+                    {language === 'es' && <>filtración de <span className="text-[var(--primary-color)]">información</span></>}
                   </h3>
                   <p className="text-gray-600 text-sm">
                     {language === 'pt' && 'identificação da origem e extensão de incidentes de vazamento de dados confidenciais, determinando como ocorreu o incidente, quais dados foram comprometidos e quem teve acesso às informações.'}
@@ -416,9 +416,9 @@ export default function ForenseCorporateInvestigationsPage() {
                 
                 <div className="bg-gray-50 rounded-lg p-8 border border-gray-100">
                   <h3 className="text-lg font-['Montserrat'] font-medium mb-4 text-gray-800 lowercase">
-                    {language === 'pt' && <>verificação de <span className="text-[#00ade0]">conformidade</span></>}
-                    {language === 'en' && <>compliance <span className="text-[#00ade0]">verification</span></>}
-                    {language === 'es' && <>verificación de <span className="text-[#00ade0]">conformidad</span></>}
+                    {language === 'pt' && <>verificação de <span className="text-[var(--primary-color)]">conformidade</span></>}
+                    {language === 'en' && <>compliance <span className="text-[var(--primary-color)]">verification</span></>}
+                    {language === 'es' && <>verificación de <span className="text-[var(--primary-color)]">conformidad</span></>}
                   </h3>
                   <p className="text-gray-600 text-sm">
                     {language === 'pt' && 'avaliação técnica do cumprimento de políticas de segurança da informação e normas regulatórias, identificando possíveis violações e fornecendo recomendações para assegurar a conformidade.'}
@@ -432,7 +432,7 @@ export default function ForenseCorporateInvestigationsPage() {
         </section>
 
         {/* CTA */}
-        <section className="contato bg-[#00ade0] flex items-center" style={{ minHeight: "400px" }}>
+        <section className="contato bg-[var(--primary-color)] flex items-center" style={{ minHeight: "400px" }}>
           <div className="container mx-auto px-4">
             <div className="max-w-4xl mx-auto text-center">
               <h2 className="text-2xl md:text-3xl font-['Montserrat'] font-normal mb-6 text-white lowercase">
@@ -440,7 +440,7 @@ export default function ForenseCorporateInvestigationsPage() {
               </h2>
               <div className="mt-8">
                 <a href={`/site/forense/contact`}
-                  className="inline-block py-3 px-8 bg-white text-[#00ade0] rounded-md font-medium transition-all hover:shadow-lg hover:bg-gray-50">
+                  className="inline-block py-3 px-8 bg-white text-[var(--primary-color)] rounded-md font-medium transition-all hover:shadow-lg hover:bg-gray-50">
                   {t('forense.cta.button')}
                 </a>
               </div>

--- a/client/src/site/forense/services/DigitalForensicsPage.tsx
+++ b/client/src/site/forense/services/DigitalForensicsPage.tsx
@@ -7,7 +7,7 @@ import { forenseStyles as styles } from '../styles';
 import { defaultContent as translations } from '../translations/services/digital-forensics';
 
 export default function ForenseDigitalForensicsPage() {
-  const DotSpan = () => <span className="text-[#00ade0]">.</span>;
+  const DotSpan = () => <span className="text-[var(--primary-color)]">.</span>;
   const { siteConfig } = useSite();
   const { language, t } = useI18n();
   
@@ -48,7 +48,7 @@ export default function ForenseDigitalForensicsPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center min-h-screen">
-          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );
@@ -95,13 +95,13 @@ export default function ForenseDigitalForensicsPage() {
                     {t('forense.digital.description3')}
                   </p>
                 </div>
-                <div className="md:w-1/2 bg-[#00ade0]/5 rounded-lg p-8 border border-[#00ade0]/20">
+                <div className="md:w-1/2 bg-[var(--primary-color)]/5 rounded-lg p-8 border border-[var(--primary-color)]/20">
                   <h3 className={`${styles.fontSizes.section.subtitle} font-['Montserrat'] font-normal ${styles.colors.text.dark} ${styles.spacing.mb.medium} lowercase`}>
                     {t('forense.digital.why')}
                   </h3>
                   <ul className="space-y-4">
                     <li className="flex items-start">
-                      <div className="bg-[#00ade0] rounded-full h-6 w-6 flex items-center justify-center mr-3 mt-0.5 flex-shrink-0">
+                      <div className="bg-[var(--primary-color)] rounded-full h-6 w-6 flex items-center justify-center mr-3 mt-0.5 flex-shrink-0">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="w-4 h-4 text-white">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                         </svg>
@@ -112,7 +112,7 @@ export default function ForenseDigitalForensicsPage() {
                       </div>
                     </li>
                     <li className="flex items-start">
-                      <div className="bg-[#00ade0] rounded-full h-6 w-6 flex items-center justify-center mr-3 mt-0.5 flex-shrink-0">
+                      <div className="bg-[var(--primary-color)] rounded-full h-6 w-6 flex items-center justify-center mr-3 mt-0.5 flex-shrink-0">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="w-4 h-4 text-white">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                         </svg>
@@ -123,7 +123,7 @@ export default function ForenseDigitalForensicsPage() {
                       </div>
                     </li>
                     <li className="flex items-start">
-                      <div className="bg-[#00ade0] rounded-full h-6 w-6 flex items-center justify-center mr-3 mt-0.5 flex-shrink-0">
+                      <div className="bg-[var(--primary-color)] rounded-full h-6 w-6 flex items-center justify-center mr-3 mt-0.5 flex-shrink-0">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" className="w-4 h-4 text-white">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                         </svg>
@@ -145,16 +145,16 @@ export default function ForenseDigitalForensicsPage() {
           <div className="container mx-auto px-4">
             <div className="max-w-5xl mx-auto">
               <h2 className="text-2xl font-['Montserrat'] font-normal mb-12 text-center lowercase">
-                {language === 'pt' && <>ambientes de <span className="text-[#00ade0]">coleta digital</span></>}
-                {language === 'en' && <>digital <span className="text-[#00ade0]">collection environments</span></>}
-                {language === 'es' && <>ambientes de <span className="text-[#00ade0]">recolección digital</span></>}
+                {language === 'pt' && <>ambientes de <span className="text-[var(--primary-color)]">coleta digital</span></>}
+                {language === 'en' && <>digital <span className="text-[var(--primary-color)]">collection environments</span></>}
+                {language === 'es' && <>ambientes de <span className="text-[var(--primary-color)]">recolección digital</span></>}
               </h2>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div className="border border-gray-800 rounded-lg p-6 bg-gray-900 hover:border-[#00ade0]/50 transition-colors duration-300 flex flex-col h-full">
+                <div className="border border-gray-800 rounded-lg p-6 bg-gray-900 hover:border-[var(--primary-color)]/50 transition-colors duration-300 flex flex-col h-full">
                   <h3 className="text-lg font-['Montserrat'] font-medium mb-3 lowercase">
-                    {language === 'pt' && <>ambientes <span className="text-[#00ade0]">corporativos</span></>}
-                    {language === 'en' && <>corporate <span className="text-[#00ade0]">environments</span></>}
-                    {language === 'es' && <>ambientes <span className="text-[#00ade0]">corporativos</span></>}
+                    {language === 'pt' && <>ambientes <span className="text-[var(--primary-color)]">corporativos</span></>}
+                    {language === 'en' && <>corporate <span className="text-[var(--primary-color)]">environments</span></>}
+                    {language === 'es' && <>ambientes <span className="text-[var(--primary-color)]">corporativos</span></>}
                   </h3>
                   <p className="text-gray-300 text-sm mb-4 flex-grow">
                     {language === 'pt' && 'análise de computadores, servidores, e dispositivos móveis corporativos, mantendo a discrição e minimizando interrupções nas operações empresariais.'}
@@ -162,7 +162,7 @@ export default function ForenseDigitalForensicsPage() {
                     {language === 'es' && 'análisis de computadoras, servidores y dispositivos móviles corporativos, manteniendo la discreción y minimizando interrupciones en las operaciones empresariales.'}
                   </p>
                   <div className="pt-4 border-t border-gray-800 mt-auto">
-                    <div className="flex items-center justify-center text-xs text-[#00ade0]/80">
+                    <div className="flex items-center justify-center text-xs text-[var(--primary-color)]/80">
                       {language === 'pt' && (
                         <>
                           <span>servidores</span>
@@ -194,11 +194,11 @@ export default function ForenseDigitalForensicsPage() {
                   </div>
                 </div>
                 
-                <div className="border border-gray-800 rounded-lg p-6 bg-gray-900 hover:border-[#00ade0]/50 transition-colors duration-300 flex flex-col h-full">
+                <div className="border border-gray-800 rounded-lg p-6 bg-gray-900 hover:border-[var(--primary-color)]/50 transition-colors duration-300 flex flex-col h-full">
                   <h3 className="text-lg font-['Montserrat'] font-medium mb-3 lowercase">
-                    {language === 'pt' && <>dispositivos <span className="text-[#00ade0]">pessoais</span></>}
-                    {language === 'en' && <>personal <span className="text-[#00ade0]">devices</span></>}
-                    {language === 'es' && <>dispositivos <span className="text-[#00ade0]">personales</span></>}
+                    {language === 'pt' && <>dispositivos <span className="text-[var(--primary-color)]">pessoais</span></>}
+                    {language === 'en' && <>personal <span className="text-[var(--primary-color)]">devices</span></>}
+                    {language === 'es' && <>dispositivos <span className="text-[var(--primary-color)]">personales</span></>}
                   </h3>
                   <p className="text-gray-300 text-sm mb-4 flex-grow">
                     {language === 'pt' && 'recuperação e análise de dados de smartphones, tablets e computadores pessoais, com atenção especial à privacidade e aos aspectos legais da coleta.'}
@@ -206,7 +206,7 @@ export default function ForenseDigitalForensicsPage() {
                     {language === 'es' && 'recuperación y análisis de datos de smartphones, tablets y computadoras personales, con atención especial a la privacidad y a los aspectos legales de la recolección.'}
                   </p>
                   <div className="pt-4 border-t border-gray-800 mt-auto">
-                    <div className="flex items-center justify-center text-xs text-[#00ade0]/80">
+                    <div className="flex items-center justify-center text-xs text-[var(--primary-color)]/80">
                       <span>smartphones</span>
                       <span className="mx-1">•</span>
                       <span>laptops</span>
@@ -216,11 +216,11 @@ export default function ForenseDigitalForensicsPage() {
                   </div>
                 </div>
                 
-                <div className="border border-gray-800 rounded-lg p-6 bg-gray-900 hover:border-[#00ade0]/50 transition-colors duration-300 flex flex-col h-full">
+                <div className="border border-gray-800 rounded-lg p-6 bg-gray-900 hover:border-[var(--primary-color)]/50 transition-colors duration-300 flex flex-col h-full">
                   <h3 className="text-lg font-['Montserrat'] font-medium mb-3 lowercase">
-                    {language === 'pt' && <>armazenamento em <span className="text-[#00ade0]">nuvem</span></>}
-                    {language === 'en' && <>cloud <span className="text-[#00ade0]">storage</span></>}
-                    {language === 'es' && <>almacenamiento en <span className="text-[#00ade0]">nube</span></>}
+                    {language === 'pt' && <>armazenamento em <span className="text-[var(--primary-color)]">nuvem</span></>}
+                    {language === 'en' && <>cloud <span className="text-[var(--primary-color)]">storage</span></>}
+                    {language === 'es' && <>almacenamiento en <span className="text-[var(--primary-color)]">nube</span></>}
                   </h3>
                   <p className="text-gray-300 text-sm mb-4 flex-grow">
                     {language === 'pt' && 'extração forense de dados armazenados em serviços de nuvem, incluindo e-mails, documentos, redes sociais, sites e backups, seguindo protocolos legais para acesso autorizado.'}
@@ -228,7 +228,7 @@ export default function ForenseDigitalForensicsPage() {
                     {language === 'es' && 'extracción forense de datos almacenados en servicios de nube, incluyendo correos electrónicos, documentos, redes sociales, sitios web y copias de seguridad, siguiendo protocolos legales para acceso autorizado.'}
                   </p>
                   <div className="pt-4 border-t border-gray-800 mt-auto">
-                    <div className="flex items-center justify-center text-xs text-[#00ade0]/80">
+                    <div className="flex items-center justify-center text-xs text-[var(--primary-color)]/80">
                       <span>AWS</span>
                       <span className="mx-1">•</span>
                       <span>Google Cloud</span>
@@ -247,15 +247,15 @@ export default function ForenseDigitalForensicsPage() {
           <div className="container mx-auto px-4">
             <div className="max-w-5xl mx-auto">
               <h2 className="text-2xl font-['Montserrat'] font-normal text-gray-800 mb-10 text-center lowercase">
-                {language === 'pt' && <>serviços <span className="text-[#00ade0]">especializados</span></>}
-                {language === 'en' && <>specialized <span className="text-[#00ade0]">services</span></>}
-                {language === 'es' && <>servicios <span className="text-[#00ade0]">especializados</span></>}
+                {language === 'pt' && <>serviços <span className="text-[var(--primary-color)]">especializados</span></>}
+                {language === 'en' && <>specialized <span className="text-[var(--primary-color)]">services</span></>}
+                {language === 'es' && <>servicios <span className="text-[var(--primary-color)]">especializados</span></>}
               </h2>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                 {content.sections.map((section, index) => (
                   <div key={index} className="bg-gray-50 p-6 rounded-lg border border-gray-100 hover:shadow-md transition-all duration-300">
                     <div className="flex items-start">
-                      <div className="w-8 h-8 bg-[#00ade0] rounded-full flex items-center justify-center mr-4 flex-shrink-0">
+                      <div className="w-8 h-8 bg-[var(--primary-color)] rounded-full flex items-center justify-center mr-4 flex-shrink-0">
                         <span className="text-white text-lg font-bold">{index + 1}</span>
                       </div>
                       <div>
@@ -281,9 +281,9 @@ export default function ForenseDigitalForensicsPage() {
               <div className="flex flex-col md:flex-row items-stretch md:space-x-10">
                 <div className="md:w-1/2 mb-10 md:mb-0">
                   <h2 className="text-2xl font-['Montserrat'] font-normal text-gray-800 mb-6 lowercase">
-                    {language === 'pt' && <>metodologias <span className="text-[#00ade0]">forenses</span></>}
-                    {language === 'en' && <>forensic <span className="text-[#00ade0]">methodologies</span></>}
-                    {language === 'es' && <>metodologías <span className="text-[#00ade0]">forenses</span></>}
+                    {language === 'pt' && <>metodologias <span className="text-[var(--primary-color)]">forenses</span></>}
+                    {language === 'en' && <>forensic <span className="text-[var(--primary-color)]">methodologies</span></>}
+                    {language === 'es' && <>metodologías <span className="text-[var(--primary-color)]">forenses</span></>}
                   </h2>
                   <p className="text-gray-700 text-sm mb-6">
                     {language === 'pt' && 'utilizamos protocolos rigorosos que garantem a admissibilidade jurídica das evidências coletadas, respeitando normas nacionais e internacionais. nossa abordagem inclui:'}
@@ -292,7 +292,7 @@ export default function ForenseDigitalForensicsPage() {
                   </p>
                   <ul className="space-y-4">
                     <li className="bg-white p-4 rounded-lg border border-gray-200 flex items-start">
-                      <span className="text-[#00ade0] text-xl mr-3 leading-6 flex-shrink-0">•</span>
+                      <span className="text-[var(--primary-color)] text-xl mr-3 leading-6 flex-shrink-0">•</span>
                       <span className="text-gray-700 text-sm">
                         {language === 'pt' && 'documentação precisa de cada etapa da coleta e cadeia de custódia'}
                         {language === 'en' && 'precise documentation of each step of the collection and chain of custody'}
@@ -300,7 +300,7 @@ export default function ForenseDigitalForensicsPage() {
                       </span>
                     </li>
                     <li className="bg-white p-4 rounded-lg border border-gray-200 flex items-start">
-                      <span className="text-[#00ade0] text-xl mr-3 leading-6 flex-shrink-0">•</span>
+                      <span className="text-[var(--primary-color)] text-xl mr-3 leading-6 flex-shrink-0">•</span>
                       <span className="text-gray-700 text-sm">
                         {language === 'pt' && 'utilização de ferramentas forenses homologadas internacionalmente'}
                         {language === 'en' && 'use of internationally certified forensic tools'}
@@ -308,7 +308,7 @@ export default function ForenseDigitalForensicsPage() {
                       </span>
                     </li>
                     <li className="bg-white p-4 rounded-lg border border-gray-200 flex items-start">
-                      <span className="text-[#00ade0] text-xl mr-3 leading-6 flex-shrink-0">•</span>
+                      <span className="text-[var(--primary-color)] text-xl mr-3 leading-6 flex-shrink-0">•</span>
                       <span className="text-gray-700 text-sm">
                         {language === 'pt' && 'técnicas não destrutivas que preservam a integridade dos dados'}
                         {language === 'en' && 'non-destructive techniques that preserve data integrity'}
@@ -316,7 +316,7 @@ export default function ForenseDigitalForensicsPage() {
                       </span>
                     </li>
                     <li className="bg-white p-4 rounded-lg border border-gray-200 flex items-start">
-                      <span className="text-[#00ade0] text-xl mr-3 leading-6 flex-shrink-0">•</span>
+                      <span className="text-[var(--primary-color)] text-xl mr-3 leading-6 flex-shrink-0">•</span>
                       <span className="text-gray-700 text-sm">
                         {language === 'pt' && 'análise de dados em ambiente isolado e controlado'}
                         {language === 'en' && 'data analysis in an isolated and controlled environment'}
@@ -327,13 +327,13 @@ export default function ForenseDigitalForensicsPage() {
                 </div>
                 <div className="md:w-1/2 bg-[#0d1117] rounded-lg p-8 text-white flex flex-col">
                   <h3 className="text-xl font-['Montserrat'] font-normal mb-6 lowercase">
-                    {language === 'pt' && <>frameworks <span className="text-[#00ade0]">adotados</span></>}
-                    {language === 'en' && <>adopted <span className="text-[#00ade0]">frameworks</span></>}
-                    {language === 'es' && <>frameworks <span className="text-[#00ade0]">adoptados</span></>}
+                    {language === 'pt' && <>frameworks <span className="text-[var(--primary-color)]">adotados</span></>}
+                    {language === 'en' && <>adopted <span className="text-[var(--primary-color)]">frameworks</span></>}
+                    {language === 'es' && <>frameworks <span className="text-[var(--primary-color)]">adoptados</span></>}
                   </h3>
                   <div className="space-y-6 flex-grow">
                     <div className="bg-gray-900 p-5 rounded-lg border border-gray-800">
-                      <h4 className="font-medium text-[#00ade0] mb-2 lowercase">ACPO Guidelines</h4>
+                      <h4 className="font-medium text-[var(--primary-color)] mb-2 lowercase">ACPO Guidelines</h4>
                       <p className="text-sm text-gray-300">
                         {language === 'pt' && 'princípios para manipulação de evidências digitais reconhecidos internacionalmente'}
                         {language === 'en' && 'internationally recognized principles for handling digital evidence'}
@@ -341,7 +341,7 @@ export default function ForenseDigitalForensicsPage() {
                       </p>
                     </div>
                     <div className="bg-gray-900 p-5 rounded-lg border border-gray-800">
-                      <h4 className="font-medium text-[#00ade0] mb-2 lowercase">ISO/IEC 27037</h4>
+                      <h4 className="font-medium text-[var(--primary-color)] mb-2 lowercase">ISO/IEC 27037</h4>
                       <p className="text-sm text-gray-300">
                         {language === 'pt' && 'diretrizes para identificação, coleta e preservação de evidências digitais'}
                         {language === 'en' && 'guidelines for identification, collection, and preservation of digital evidence'}
@@ -349,7 +349,7 @@ export default function ForenseDigitalForensicsPage() {
                       </p>
                     </div>
                     <div className="bg-gray-900 p-5 rounded-lg border border-gray-800">
-                      <h4 className="font-medium text-[#00ade0] mb-2 lowercase">NIST Guidelines</h4>
+                      <h4 className="font-medium text-[var(--primary-color)] mb-2 lowercase">NIST Guidelines</h4>
                       <p className="text-sm text-gray-300">
                         {language === 'pt' && 'padrões técnicos para forensics digital e investigações cibernéticas'}
                         {language === 'en' && 'technical standards for digital forensics and cyber investigations'}
@@ -371,7 +371,7 @@ export default function ForenseDigitalForensicsPage() {
             </h2>
             <a
               href={`/site/forense/contact`}
-              className="inline-block bg-[#00ade0] hover:bg-opacity-90 text-white py-3 px-8 rounded lowercase transition duration-300"
+              className="inline-block bg-[var(--primary-color)] hover:bg-opacity-90 text-white py-3 px-8 rounded lowercase transition duration-300"
             >
               {t('forense.cta.button')}
             </a>

--- a/client/src/site/forense/services/LegalSupportPage.tsx
+++ b/client/src/site/forense/services/LegalSupportPage.tsx
@@ -7,7 +7,7 @@ import { forenseStyles as styles } from '../styles';
 import { defaultContent as translations } from '../translations/services/legal-support';
 
 export default function ForenseLegalSupportPage() {
-  const DotSpan = () => <span className="text-[#00ade0]">.</span>;
+  const DotSpan = () => <span className="text-[var(--primary-color)]">.</span>;
   const { siteConfig } = useSite();
   const { language, t } = useI18n();
   
@@ -55,7 +55,7 @@ export default function ForenseLegalSupportPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center min-h-screen">
-          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );
@@ -95,19 +95,19 @@ export default function ForenseLegalSupportPage() {
                     <h2 className="text-2xl font-['Montserrat'] font-normal mb-6 lowercase">
                       {language === 'pt' && (
                         <>
-                          <span className="text-white bg-[#00ade0] px-2 py-1 rounded-sm">consultoria técnica</span>
+                          <span className="text-white bg-[var(--primary-color)] px-2 py-1 rounded-sm">consultoria técnica</span>
                           <span className="ml-2">especializada</span>
                         </>
                       )}
                       {language === 'en' && (
                         <>
                           <span className="mr-2">specialized</span>
-                          <span className="text-white bg-[#00ade0] px-2 py-1 rounded-sm">technical consulting</span>
+                          <span className="text-white bg-[var(--primary-color)] px-2 py-1 rounded-sm">technical consulting</span>
                         </>
                       )}
                       {language === 'es' && (
                         <>
-                          <span className="text-white bg-[#00ade0] px-2 py-1 rounded-sm">consultoría técnica</span>
+                          <span className="text-white bg-[var(--primary-color)] px-2 py-1 rounded-sm">consultoría técnica</span>
                           <span className="ml-2">especializada</span>
                         </>
                       )}
@@ -125,7 +125,7 @@ export default function ForenseLegalSupportPage() {
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
                       <div className="bg-white p-5 rounded-md border border-gray-100 shadow-sm">
                         <h4 className="font-medium text-gray-900 mb-2 lowercase">
-                          <div className="h-2 w-2 rounded-full bg-[#00ade0] inline-block mr-2"></div>
+                          <div className="h-2 w-2 rounded-full bg-[var(--primary-color)] inline-block mr-2"></div>
                           {t('forense.legal.analysis.title')}
                         </h4>
                         <p className="text-gray-600 text-sm">
@@ -135,7 +135,7 @@ export default function ForenseLegalSupportPage() {
                       
                       <div className="bg-white p-5 rounded-md border border-gray-100 shadow-sm">
                         <h4 className="font-medium text-gray-900 mb-2 lowercase">
-                          <div className="h-2 w-2 rounded-full bg-[#00ade0] inline-block mr-2"></div>
+                          <div className="h-2 w-2 rounded-full bg-[var(--primary-color)] inline-block mr-2"></div>
                           {t('forense.legal.translation.title')}
                         </h4>
                         <p className="text-gray-600 text-sm">
@@ -145,7 +145,7 @@ export default function ForenseLegalSupportPage() {
                       
                       <div className="bg-white p-5 rounded-md border border-gray-100 shadow-sm">
                         <h4 className="font-medium text-gray-900 mb-2 lowercase">
-                          <div className="h-2 w-2 rounded-full bg-[#00ade0] inline-block mr-2"></div>
+                          <div className="h-2 w-2 rounded-full bg-[var(--primary-color)] inline-block mr-2"></div>
                           {t('forense.legal.standards.title')}
                         </h4>
                         <p className="text-gray-600 text-sm">
@@ -173,18 +173,18 @@ export default function ForenseLegalSupportPage() {
               
               <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
                 {/* Consultoria Estratégica */}
-                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[#00ade0]/30 flex flex-col h-full">
+                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[var(--primary-color)]/30 flex flex-col h-full">
                   <div className="p-8 flex flex-col h-full">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase">
-                      {language === 'pt' && <>consultoria <span className="text-[#00ade0]">estratégica</span></>}
-                      {language === 'en' && <>strategic <span className="text-[#00ade0]">consulting</span></>}
-                      {language === 'es' && <>consultoría <span className="text-[#00ade0]">estratégica</span></>}
+                      {language === 'pt' && <>consultoria <span className="text-[var(--primary-color)]">estratégica</span></>}
+                      {language === 'en' && <>strategic <span className="text-[var(--primary-color)]">consulting</span></>}
+                      {language === 'es' && <>consultoría <span className="text-[var(--primary-color)]">estratégica</span></>}
                     </h3>
                     <p className="text-gray-600 mb-6 leading-relaxed flex-grow">
                       {content.sections[0].content}
                     </p>
                     <div className="mt-auto pt-6 border-t border-gray-100">
-                      <div className="flex justify-center text-xs text-[#00ade0]/80">
+                      <div className="flex justify-center text-xs text-[var(--primary-color)]/80">
                         <div className="grid grid-cols-3 gap-2 w-full">
                           {language === 'pt' && (
                             <>
@@ -214,18 +214,18 @@ export default function ForenseLegalSupportPage() {
                 </div>
                 
                 {/* Assistência Técnica Processual */}
-                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[#00ade0]/30 flex flex-col h-full">
+                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[var(--primary-color)]/30 flex flex-col h-full">
                   <div className="p-8 flex flex-col h-full">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase">
-                      {language === 'pt' && <>assistência <span className="text-[#00ade0]">técnica processual</span></>}
-                      {language === 'en' && <>procedural <span className="text-[#00ade0]">technical assistance</span></>}
-                      {language === 'es' && <>asistencia <span className="text-[#00ade0]">técnica procesal</span></>}
+                      {language === 'pt' && <>assistência <span className="text-[var(--primary-color)]">técnica processual</span></>}
+                      {language === 'en' && <>procedural <span className="text-[var(--primary-color)]">technical assistance</span></>}
+                      {language === 'es' && <>asistencia <span className="text-[var(--primary-color)]">técnica procesal</span></>}
                     </h3>
                     <p className="text-gray-600 mb-6 leading-relaxed flex-grow">
                       {content.sections[1].content}
                     </p>
                     <div className="mt-auto pt-6 border-t border-gray-100">
-                      <div className="flex justify-center text-xs text-[#00ade0]/80">
+                      <div className="flex justify-center text-xs text-[var(--primary-color)]/80">
                         <div className="grid grid-cols-3 gap-2 w-full">
                           {language === 'pt' && (
                             <>
@@ -255,18 +255,18 @@ export default function ForenseLegalSupportPage() {
                 </div>
                 
                 {/* Esclarecimentos Técnicos em Audiências */}
-                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[#00ade0]/30 flex flex-col h-full">
+                <div className="bg-white rounded-lg overflow-hidden shadow-sm border border-gray-100 transition-all hover:shadow-md hover:border-[var(--primary-color)]/30 flex flex-col h-full">
                   <div className="p-8 flex flex-col h-full">
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase">
-                      {language === 'pt' && <>esclarecimentos <span className="text-[#00ade0]">em audiências</span></>}
-                      {language === 'en' && <>clarification <span className="text-[#00ade0]">in hearings</span></>}
-                      {language === 'es' && <>aclaraciones <span className="text-[#00ade0]">en audiencias</span></>}
+                      {language === 'pt' && <>esclarecimentos <span className="text-[var(--primary-color)]">em audiências</span></>}
+                      {language === 'en' && <>clarification <span className="text-[var(--primary-color)]">in hearings</span></>}
+                      {language === 'es' && <>aclaraciones <span className="text-[var(--primary-color)]">en audiencias</span></>}
                     </h3>
                     <p className="text-gray-600 mb-6 leading-relaxed flex-grow">
                       {content.sections[2].content}
                     </p>
                     <div className="mt-auto pt-6 border-t border-gray-100">
-                      <div className="flex justify-center text-xs text-[#00ade0]/80">
+                      <div className="flex justify-center text-xs text-[var(--primary-color)]/80">
                         <div className="grid grid-cols-3 gap-2 w-full">
                           {language === 'pt' && (
                             <>
@@ -306,17 +306,17 @@ export default function ForenseLegalSupportPage() {
               <h2 className="text-2xl font-['Montserrat'] font-normal mb-16 text-center lowercase">
                 {language === 'pt' && (
                   <>
-                    nossa <span className="text-white bg-[#00ade0] px-2 py-1 rounded-sm">metodologia</span>
+                    nossa <span className="text-white bg-[var(--primary-color)] px-2 py-1 rounded-sm">metodologia</span>
                   </>
                 )}
                 {language === 'en' && (
                   <>
-                    our <span className="text-white bg-[#00ade0] px-2 py-1 rounded-sm">methodology</span>
+                    our <span className="text-white bg-[var(--primary-color)] px-2 py-1 rounded-sm">methodology</span>
                   </>
                 )}
                 {language === 'es' && (
                   <>
-                    nuestra <span className="text-white bg-[#00ade0] px-2 py-1 rounded-sm">metodología</span>
+                    nuestra <span className="text-white bg-[var(--primary-color)] px-2 py-1 rounded-sm">metodología</span>
                   </>
                 )}
               </h2>
@@ -324,13 +324,13 @@ export default function ForenseLegalSupportPage() {
                 <div className="flex flex-col md:flex-row items-start gap-8">
                   <div className="md:w-1/3">
                     <div className="mb-4 flex items-center">
-                      <span className="text-4xl font-light text-[#00ade0]">01</span>
-                      <div className="ml-4 h-[1px] flex-grow bg-[#00ade0]/30"></div>
+                      <span className="text-4xl font-light text-[var(--primary-color)]">01</span>
+                      <div className="ml-4 h-[1px] flex-grow bg-[var(--primary-color)]/30"></div>
                     </div>
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-3 lowercase">
-                      {language === 'pt' && <>análise <span className="text-[#00ade0]">preliminar</span></>}
-                      {language === 'en' && <>preliminary <span className="text-[#00ade0]">analysis</span></>}
-                      {language === 'es' && <>análisis <span className="text-[#00ade0]">preliminar</span></>}
+                      {language === 'pt' && <>análise <span className="text-[var(--primary-color)]">preliminar</span></>}
+                      {language === 'en' && <>preliminary <span className="text-[var(--primary-color)]">analysis</span></>}
+                      {language === 'es' && <>análisis <span className="text-[var(--primary-color)]">preliminar</span></>}
                     </h3>
                   </div>
                   <div className="md:w-2/3">
@@ -345,13 +345,13 @@ export default function ForenseLegalSupportPage() {
                 <div className="flex flex-col md:flex-row items-start gap-8">
                   <div className="md:w-1/3">
                     <div className="mb-4 flex items-center">
-                      <span className="text-4xl font-light text-[#00ade0]">02</span>
-                      <div className="ml-4 h-[1px] flex-grow bg-[#00ade0]/30"></div>
+                      <span className="text-4xl font-light text-[var(--primary-color)]">02</span>
+                      <div className="ml-4 h-[1px] flex-grow bg-[var(--primary-color)]/30"></div>
                     </div>
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-3 lowercase">
-                      {language === 'pt' && <>planejamento <span className="text-[#00ade0]">estratégico</span></>}
-                      {language === 'en' && <>strategic <span className="text-[#00ade0]">planning</span></>}
-                      {language === 'es' && <>planificación <span className="text-[#00ade0]">estratégica</span></>}
+                      {language === 'pt' && <>planejamento <span className="text-[var(--primary-color)]">estratégico</span></>}
+                      {language === 'en' && <>strategic <span className="text-[var(--primary-color)]">planning</span></>}
+                      {language === 'es' && <>planificación <span className="text-[var(--primary-color)]">estratégica</span></>}
                     </h3>
                   </div>
                   <div className="md:w-2/3">
@@ -366,13 +366,13 @@ export default function ForenseLegalSupportPage() {
                 <div className="flex flex-col md:flex-row items-start gap-8">
                   <div className="md:w-1/3">
                     <div className="mb-4 flex items-center">
-                      <span className="text-4xl font-light text-[#00ade0]">03</span>
-                      <div className="ml-4 h-[1px] flex-grow bg-[#00ade0]/30"></div>
+                      <span className="text-4xl font-light text-[var(--primary-color)]">03</span>
+                      <div className="ml-4 h-[1px] flex-grow bg-[var(--primary-color)]/30"></div>
                     </div>
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-3 lowercase">
-                      {language === 'pt' && <>execução <span className="text-[#00ade0]">técnica</span></>}
-                      {language === 'en' && <>technical <span className="text-[#00ade0]">execution</span></>}
-                      {language === 'es' && <>ejecución <span className="text-[#00ade0]">técnica</span></>}
+                      {language === 'pt' && <>execução <span className="text-[var(--primary-color)]">técnica</span></>}
+                      {language === 'en' && <>technical <span className="text-[var(--primary-color)]">execution</span></>}
+                      {language === 'es' && <>ejecución <span className="text-[var(--primary-color)]">técnica</span></>}
                     </h3>
                   </div>
                   <div className="md:w-2/3">
@@ -387,13 +387,13 @@ export default function ForenseLegalSupportPage() {
                 <div className="flex flex-col md:flex-row items-start gap-8">
                   <div className="md:w-1/3">
                     <div className="mb-4 flex items-center">
-                      <span className="text-4xl font-light text-[#00ade0]">04</span>
-                      <div className="ml-4 h-[1px] flex-grow bg-[#00ade0]/30"></div>
+                      <span className="text-4xl font-light text-[var(--primary-color)]">04</span>
+                      <div className="ml-4 h-[1px] flex-grow bg-[var(--primary-color)]/30"></div>
                     </div>
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-3 lowercase">
-                      {language === 'pt' && <>comunicação <span className="text-[#00ade0]">eficaz</span></>}
-                      {language === 'en' && <>effective <span className="text-[#00ade0]">communication</span></>}
-                      {language === 'es' && <>comunicación <span className="text-[#00ade0]">eficaz</span></>}
+                      {language === 'pt' && <>comunicação <span className="text-[var(--primary-color)]">eficaz</span></>}
+                      {language === 'en' && <>effective <span className="text-[var(--primary-color)]">communication</span></>}
+                      {language === 'es' && <>comunicación <span className="text-[var(--primary-color)]">eficaz</span></>}
                     </h3>
                   </div>
                   <div className="md:w-2/3">
@@ -416,32 +416,32 @@ export default function ForenseLegalSupportPage() {
               <h2 className="text-2xl font-['Montserrat'] font-normal mb-16 text-center lowercase">
                 {language === 'pt' && (
                   <>
-                    benefícios do nosso <span className="text-white bg-[#00ade0] px-2 py-1 rounded-sm">suporte à área legal</span>
+                    benefícios do nosso <span className="text-white bg-[var(--primary-color)] px-2 py-1 rounded-sm">suporte à área legal</span>
                   </>
                 )}
                 {language === 'en' && (
                   <>
-                    benefits of our <span className="text-white bg-[#00ade0] px-2 py-1 rounded-sm">technical support for the legal field</span>
+                    benefits of our <span className="text-white bg-[var(--primary-color)] px-2 py-1 rounded-sm">technical support for the legal field</span>
                   </>
                 )}
                 {language === 'es' && (
                   <>
-                    beneficios de nuestro <span className="text-white bg-[#00ade0] px-2 py-1 rounded-sm">soporte técnico para el área legal</span>
+                    beneficios de nuestro <span className="text-white bg-[var(--primary-color)] px-2 py-1 rounded-sm">soporte técnico para el área legal</span>
                   </>
                 )}
               </h2>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
                 <div className="flex">
                   <div className="mr-6">
-                    <div className="h-12 w-12 border border-[#00ade0] rounded-full flex items-center justify-center">
-                      <div className="h-8 w-8 bg-[#00ade0] rounded-full"></div>
+                    <div className="h-12 w-12 border border-[var(--primary-color)] rounded-full flex items-center justify-center">
+                      <div className="h-8 w-8 bg-[var(--primary-color)] rounded-full"></div>
                     </div>
                   </div>
                   <div>
                     <h3 className="text-lg font-['Montserrat'] font-medium mb-3 lowercase">
-                      {language === 'pt' && <>argumentação <span className="text-[#00ade0]">robusta</span></>}
-                      {language === 'en' && <>robust <span className="text-[#00ade0]">argumentation</span></>}
-                      {language === 'es' && <>argumentación <span className="text-[#00ade0]">sólida</span></>}
+                      {language === 'pt' && <>argumentação <span className="text-[var(--primary-color)]">robusta</span></>}
+                      {language === 'en' && <>robust <span className="text-[var(--primary-color)]">argumentation</span></>}
+                      {language === 'es' && <>argumentación <span className="text-[var(--primary-color)]">sólida</span></>}
                     </h3>
                     <p className="text-gray-600 leading-relaxed">
                       {language === 'pt' && 'fortalecemos argumentos jurídicos com embasamento técnico sólido, aumentando sua credibilidade e poder de persuasão perante os tribunais e demais autoridades.'}
@@ -453,15 +453,15 @@ export default function ForenseLegalSupportPage() {
                 
                 <div className="flex">
                   <div className="mr-6">
-                    <div className="h-12 w-12 border border-[#00ade0] rounded-full flex items-center justify-center">
-                      <div className="h-8 w-8 bg-[#00ade0] rounded-full"></div>
+                    <div className="h-12 w-12 border border-[var(--primary-color)] rounded-full flex items-center justify-center">
+                      <div className="h-8 w-8 bg-[var(--primary-color)] rounded-full"></div>
                     </div>
                   </div>
                   <div>
                     <h3 className="text-lg font-['Montserrat'] font-medium mb-3 lowercase">
-                      {language === 'pt' && <>identificação de <span className="text-[#00ade0]">vulnerabilidades</span></>}
-                      {language === 'en' && <>vulnerability <span className="text-[#00ade0]">identification</span></>}
-                      {language === 'es' && <>identificación de <span className="text-[#00ade0]">vulnerabilidades</span></>}
+                      {language === 'pt' && <>identificação de <span className="text-[var(--primary-color)]">vulnerabilidades</span></>}
+                      {language === 'en' && <>vulnerability <span className="text-[var(--primary-color)]">identification</span></>}
+                      {language === 'es' && <>identificación de <span className="text-[var(--primary-color)]">vulnerabilidades</span></>}
                     </h3>
                     <p className="text-gray-600 leading-relaxed">
                       {language === 'pt' && 'analisamos criticamente as evidências e argumentos técnicos apresentados pela parte contrária, identificando falhas metodológicas e inconsistências que podem ser exploradas estrategicamente.'}
@@ -473,15 +473,15 @@ export default function ForenseLegalSupportPage() {
                 
                 <div className="flex">
                   <div className="mr-6">
-                    <div className="h-12 w-12 border border-[#00ade0] rounded-full flex items-center justify-center">
-                      <div className="h-8 w-8 bg-[#00ade0] rounded-full"></div>
+                    <div className="h-12 w-12 border border-[var(--primary-color)] rounded-full flex items-center justify-center">
+                      <div className="h-8 w-8 bg-[var(--primary-color)] rounded-full"></div>
                     </div>
                   </div>
                   <div>
                     <h3 className="text-lg font-['Montserrat'] font-medium mb-3 lowercase">
-                      {language === 'pt' && <>clareza <span className="text-[#00ade0]">técnica</span></>}
-                      {language === 'en' && <>technical <span className="text-[#00ade0]">clarity</span></>}
-                      {language === 'es' && <>claridad <span className="text-[#00ade0]">técnica</span></>}
+                      {language === 'pt' && <>clareza <span className="text-[var(--primary-color)]">técnica</span></>}
+                      {language === 'en' && <>technical <span className="text-[var(--primary-color)]">clarity</span></>}
+                      {language === 'es' && <>claridad <span className="text-[var(--primary-color)]">técnica</span></>}
                     </h3>
                     <p className="text-gray-600 leading-relaxed">
                       {language === 'pt' && 'facilitamos o entendimento de questões técnicas complexas por parte de juízes, advogados e demais envolvidos no processo, evitando mal-entendidos e interpretações equivocadas.'}
@@ -493,15 +493,15 @@ export default function ForenseLegalSupportPage() {
                 
                 <div className="flex">
                   <div className="mr-6">
-                    <div className="h-12 w-12 border border-[#00ade0] rounded-full flex items-center justify-center">
-                      <div className="h-8 w-8 bg-[#00ade0] rounded-full"></div>
+                    <div className="h-12 w-12 border border-[var(--primary-color)] rounded-full flex items-center justify-center">
+                      <div className="h-8 w-8 bg-[var(--primary-color)] rounded-full"></div>
                     </div>
                   </div>
                   <div>
                     <h3 className="text-lg font-['Montserrat'] font-medium mb-3 lowercase">
-                      {language === 'pt' && <>vantagem <span className="text-[#00ade0]">competitiva</span></>}
-                      {language === 'en' && <>competitive <span className="text-[#00ade0]">advantage</span></>}
-                      {language === 'es' && <>ventaja <span className="text-[#00ade0]">competitiva</span></>}
+                      {language === 'pt' && <>vantagem <span className="text-[var(--primary-color)]">competitiva</span></>}
+                      {language === 'en' && <>competitive <span className="text-[var(--primary-color)]">advantage</span></>}
+                      {language === 'es' && <>ventaja <span className="text-[var(--primary-color)]">competitiva</span></>}
                     </h3>
                     <p className="text-gray-600 leading-relaxed">
                       {language === 'pt' && 'proporcionamos um diferencial estratégico em casos complexos, onde o domínio do aspecto técnico das evidências digitais pode ser decisivo para o resultado final do processo.'}
@@ -516,7 +516,7 @@ export default function ForenseLegalSupportPage() {
         </section>
 
         {/* CTA */}
-        <section className="contato bg-[#00ade0] flex items-center" style={{ minHeight: "400px" }}>
+        <section className="contato bg-[var(--primary-color)] flex items-center" style={{ minHeight: "400px" }}>
           <div className="container mx-auto px-4">
             <div className="max-w-4xl mx-auto text-center">
               <h2 className="text-2xl md:text-3xl font-['Montserrat'] font-normal mb-6 text-white lowercase">
@@ -524,7 +524,7 @@ export default function ForenseLegalSupportPage() {
               </h2>
               <div className="mt-8">
                 <a href="/contato" 
-                  className="inline-block py-3 px-8 bg-white text-[#00ade0] rounded-md font-medium transition-all hover:shadow-lg hover:bg-gray-50">
+                  className="inline-block py-3 px-8 bg-white text-[var(--primary-color)] rounded-md font-medium transition-all hover:shadow-lg hover:bg-gray-50">
                   {content.cta.button}
                 </a>
               </div>

--- a/client/src/site/layout/SiteFooter.tsx
+++ b/client/src/site/layout/SiteFooter.tsx
@@ -313,23 +313,23 @@ export default function SiteFooter() {
               {/* Links para outras marcas */}
               <div className="flex gap-x-4 ml-4 pl-4 border-l border-gray-700">
                 {siteConfig.code !== 'ness' && (
-                  <div className="text-gray-300 hover:text-[#00ade0] transition duration-300 whitespace-nowrap">
+                  <div className="text-gray-300 hover:text-[var(--primary-color)] transition duration-300 whitespace-nowrap">
                     <Link href="/site/ness">
-                      ness<span className="text-[#00ade0]">.</span>
+                      ness<span className="text-[var(--primary-color)]">.</span>
                     </Link>
                   </div>
                 )}
                 {siteConfig.code !== 'trustness' && (
-                  <div className="text-gray-300 hover:text-[#00ade0] transition duration-300 whitespace-nowrap">
+                  <div className="text-gray-300 hover:text-[var(--primary-color)] transition duration-300 whitespace-nowrap">
                     <Link href="/site/trustness">
-                      trustness<span className="text-[#00ade0]">.</span>
+                      trustness<span className="text-[var(--primary-color)]">.</span>
                     </Link>
                   </div>
                 )}
                 {siteConfig.code !== 'forense' && (
-                  <div className="text-gray-300 hover:text-[#00ade0] transition duration-300 whitespace-nowrap">
+                  <div className="text-gray-300 hover:text-[var(--primary-color)] transition duration-300 whitespace-nowrap">
                     <Link href="/site/forense">
-                      forense<span className="text-[#00ade0]">.</span>io
+                      forense<span className="text-[var(--primary-color)]">.</span>io
                     </Link>
                   </div>
                 )}

--- a/client/src/site/layout/SiteNavbar.tsx
+++ b/client/src/site/layout/SiteNavbar.tsx
@@ -87,8 +87,8 @@ export default function SiteNavbar() {
             <Link href={sitePrefix} className="text-white lowercase">
               <h1 className="font-['Montserrat'] font-normal text-3xl">
                 {siteConfig.code === 'forense' 
-                  ? <>forense<span style={{color: "#00ade0", marginLeft: "1px"}}>.</span>io</>
-                  : <>{siteConfig.name.replace('.', '')}<span style={{color: "#00ade0", marginLeft: "1px"}}>.</span></>
+                  ? <>forense<span style={{color: "var(--primary-color)", marginLeft: "1px"}}>.</span>io</>
+                  : <>{siteConfig.name.replace('.', '')}<span style={{color: "var(--primary-color)", marginLeft: "1px"}}>.</span></>
                 }
               </h1>
             </Link>
@@ -128,9 +128,9 @@ export default function SiteNavbar() {
                         onClick={() => setServicesDropdownOpen(false)}
                       >
                         {siteConfig.code === 'ness' ? (
-                          <>n<span className="text-[#00ade0]">.</span>{service.name.substring(2)}</>
+                          <>n<span className="text-[var(--primary-color)]">.</span>{service.name.substring(2)}</>
                         ) : siteConfig.code === 'trustness' ? (
-                          <><span className="text-[#005fa3]">.</span>{service.name.substring(1)}</>
+                          <><span className="text-[var(--primary-color)]">.</span>{service.name.substring(1)}</>
                         ) : siteConfig.code === 'forense' ? (
                           service.id === 'digital-forensics' ? (
                             <>
@@ -174,7 +174,7 @@ export default function SiteNavbar() {
             {/* Contact as a button */}
             <Link 
               href={`${sitePrefix}/contact`} 
-              className={`${siteConfig.code === 'forense' ? 'bg-[#00ade0]' : 'bg-[var(--primary-color)]'} hover:bg-opacity-90 text-white py-1.5 px-3 rounded-sm transition duration-200 text-sm lowercase ml-2`}
+              className={`${siteConfig.code === 'forense' ? 'bg-[var(--primary-color)]' : 'bg-[var(--primary-color)]'} hover:bg-opacity-90 text-white py-1.5 px-3 rounded-sm transition duration-200 text-sm lowercase ml-2`}
             >
               {t('nav.contact')}
             </Link>
@@ -214,9 +214,9 @@ export default function SiteNavbar() {
                   className="text-gray-300 hover:text-accent transition duration-200 pl-3 pb-1 text-sm lowercase block"
                 >
                   {siteConfig.code === 'ness' ? (
-                    <>n<span className="text-[#00ade0]">.</span>{service.name.substring(2)}</>
+                    <>n<span className="text-[var(--primary-color)]">.</span>{service.name.substring(2)}</>
                   ) : siteConfig.code === 'trustness' ? (
-                    <><span className="text-[#005fa3]">.</span>{service.name.substring(1)}</>
+                    <><span className="text-[var(--primary-color)]">.</span>{service.name.substring(1)}</>
                   ) : siteConfig.code === 'forense' ? (
                     service.id === 'digital-forensics' ? (
                       <>
@@ -253,7 +253,7 @@ export default function SiteNavbar() {
               </div>
               <Link 
                 href={`${sitePrefix}/contact`} 
-                className={`${siteConfig.code === 'forense' ? 'bg-[#00ade0]' : 'bg-[var(--primary-color)]'} hover:bg-opacity-90 text-white py-2 px-4 rounded-sm transition duration-200 text-center lowercase`}
+                className={`${siteConfig.code === 'forense' ? 'bg-[var(--primary-color)]' : 'bg-[var(--primary-color)]'} hover:bg-opacity-90 text-white py-2 px-4 rounded-sm transition duration-200 text-center lowercase`}
               >
                 {t('nav.contact')}
               </Link>

--- a/client/src/site/ness/AboutPage.tsx
+++ b/client/src/site/ness/AboutPage.tsx
@@ -71,7 +71,7 @@ export default function NessAboutPage() {
           <div className="container mx-auto px-4 z-10 flex justify-center items-center h-full">
             <div className="hero-main-content text-center max-w-4xl">
               <h1 className="text-5xl md:text-6xl lg:text-7xl font-['Montserrat'] font-normal mb-6">
-                <span style={{color: "#ffffff"}}>ness</span><span style={{color: "#00ade0"}}>.</span>
+                <span style={{color: "#ffffff"}}>ness</span><span style={{color: "var(--primary-color)"}}>.</span>
               </h1>
               <p className="text-2xl md:text-3xl lg:text-4xl font-['Montserrat'] font-normal mb-6 text-white lowercase tracking-tight">
                 {defaultContent.heroTitle}
@@ -89,16 +89,16 @@ export default function NessAboutPage() {
           <div className="container mx-auto px-4">
             <div className="max-w-3xl mx-auto">
               <h2 className="font-['Montserrat'] font-normal text-2xl md:text-3xl mb-6 text-center lowercase">
-                <span className="font-normal">{language === 'pt' ? 'somos a' : language === 'es' ? 'somos' : 'we are'}</span> <span className="text-black font-normal">ness<span className="text-[#00ade0]">.</span></span>
+                <span className="font-normal">{language === 'pt' ? 'somos a' : language === 'es' ? 'somos' : 'we are'}</span> <span className="text-black font-normal">ness<span className="text-[var(--primary-color)]">.</span></span>
               </h2>
               
               <div className="prose prose-base mx-auto text-gray-700 lowercase">
                 <p className="mb-6 text-center font-light tracking-wide text-lg">
                   {language === 'pt' 
-                    ? <>tecnologia clara <span className="text-[#00ade0]">•</span> estrutura segura <span className="text-[#00ade0]">•</span> propósito real</>
+                    ? <>tecnologia clara <span className="text-[var(--primary-color)]">•</span> estrutura segura <span className="text-[var(--primary-color)]">•</span> propósito real</>
                     : language === 'en'
-                      ? <>clear technology <span className="text-[#00ade0]">•</span> secure structure <span className="text-[#00ade0]">•</span> real purpose</>
-                      : <>tecnología clara <span className="text-[#00ade0]">•</span> estructura segura <span className="text-[#00ade0]">•</span> propósito real</>
+                      ? <>clear technology <span className="text-[var(--primary-color)]">•</span> secure structure <span className="text-[var(--primary-color)]">•</span> real purpose</>
+                      : <>tecnología clara <span className="text-[var(--primary-color)]">•</span> estructura segura <span className="text-[var(--primary-color)]">•</span> propósito real</>
                   }
                 </p>
                 
@@ -127,11 +127,11 @@ export default function NessAboutPage() {
         {/* Values Section */}
         <section className="conteudo bg-[#2c2c34]" style={{ padding: "4rem 0" }}>
           <div className="container mx-auto px-4">
-            <h2 className="text-3xl font-['Montserrat'] font-normal text-center mb-12 lowercase text-[#00ade0]">{defaultContent.values.title}</h2>
+            <h2 className="text-3xl font-['Montserrat'] font-normal text-center mb-12 lowercase text-[var(--primary-color)]">{defaultContent.values.title}</h2>
             
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               {/* Vision */}
-              <div className="bg-[#38383f] p-8 rounded-sm border-l-2 border-[#00ade0]">
+              <div className="bg-[#38383f] p-8 rounded-sm border-l-2 border-[var(--primary-color)]">
                 <h3 className="text-xl font-['Montserrat'] font-medium mb-4 lowercase text-white">
                   {defaultContent.values.vision.title}
                 </h3>
@@ -141,7 +141,7 @@ export default function NessAboutPage() {
               </div>
               
               {/* Mission */}
-              <div className="bg-[#38383f] p-8 rounded-sm border-l-2 border-[#00ade0]">
+              <div className="bg-[#38383f] p-8 rounded-sm border-l-2 border-[var(--primary-color)]">
                 <h3 className="text-xl font-['Montserrat'] font-medium mb-4 lowercase text-white">
                   {defaultContent.values.mission.title}
                 </h3>
@@ -151,7 +151,7 @@ export default function NessAboutPage() {
               </div>
               
               {/* Values */}
-              <div className="bg-[#38383f] p-8 rounded-sm border-l-2 border-[#00ade0]">
+              <div className="bg-[#38383f] p-8 rounded-sm border-l-2 border-[var(--primary-color)]">
                 <h3 className="text-xl font-['Montserrat'] font-medium mb-4 lowercase text-white">
                   {defaultContent.values.values.title}
                 </h3>
@@ -174,7 +174,7 @@ export default function NessAboutPage() {
             <div className="max-w-5xl mx-auto">
               <div className="relative">
                 {/* Linha do tempo vertical */}
-                <div className="absolute left-1/2 transform -translate-x-1/2 h-full w-px bg-[#00ade0] opacity-50"></div>
+                <div className="absolute left-1/2 transform -translate-x-1/2 h-full w-px bg-[var(--primary-color)] opacity-50"></div>
                 
                 {/* Eventos na linha do tempo */}
                 {Object.entries(defaultContent.timelineEvents).map(([year, description], index) => (
@@ -183,7 +183,7 @@ export default function NessAboutPage() {
                       <div className={`${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
                         <span className="text-2xl font-['Montserrat'] font-medium text-gray-900">
                           {year.includes('.') ? year.split('.')[0] : year}
-                          {year.includes('.') && <span className="text-[#00ade0] text-sm">.{year.split('.')[1]}</span>}
+                          {year.includes('.') && <span className="text-[var(--primary-color)] text-sm">.{year.split('.')[1]}</span>}
                         </span>
                         <p className="mt-2 text-gray-700 lowercase">
                           {description}
@@ -191,7 +191,7 @@ export default function NessAboutPage() {
                       </div>
                     </div>
                     
-                    <div className="absolute left-1/2 transform -translate-x-1/2 w-4 h-4 bg-[#00ade0] rounded-full mt-1"></div>
+                    <div className="absolute left-1/2 transform -translate-x-1/2 w-4 h-4 bg-[var(--primary-color)] rounded-full mt-1"></div>
                     
                     <div className="w-1/2 px-6"></div>
                   </div>
@@ -206,16 +206,16 @@ export default function NessAboutPage() {
           <div className="container mx-auto px-4 text-center">
             <h2 className="text-3xl font-['Montserrat'] font-normal mb-8 lowercase">
               {language === 'pt' 
-                ? <>quer saber mais sobre a <span className="font-normal">ness<span className="text-[#00ade0]">.</span></span>?</> 
+                ? <>quer saber mais sobre a <span className="font-normal">ness<span className="text-[var(--primary-color)]">.</span></span>?</> 
                 : language === 'en'
-                  ? <>want to know more about <span className="font-normal">ness<span className="text-[#00ade0]">.</span></span>?</>
-                  : <>¿quieres saber más sobre <span className="font-normal">ness<span className="text-[#00ade0]">.</span></span>?</>
+                  ? <>want to know more about <span className="font-normal">ness<span className="text-[var(--primary-color)]">.</span></span>?</>
+                  : <>¿quieres saber más sobre <span className="font-normal">ness<span className="text-[var(--primary-color)]">.</span></span>?</>
               }
             </h2>
             
             <a 
               href="/site/ness/contact" 
-              className="inline-block bg-[#00ade0] hover:bg-opacity-90 text-white py-3 px-8 rounded lowercase transition duration-300"
+              className="inline-block bg-[var(--primary-color)] hover:bg-opacity-90 text-white py-3 px-8 rounded lowercase transition duration-300"
             >
               {defaultContent.cta.button}
             </a>

--- a/client/src/site/ness/HomePage.tsx
+++ b/client/src/site/ness/HomePage.tsx
@@ -49,17 +49,17 @@ export default function NessHomePage() {
         title={
           language === 'pt' ? (
             pageContent?.content && JSON.parse(pageContent.content).heroTitle || 
-            <>use <span className="text-[#00ade0]">tecnologia</span> segura, escalável e inteligente para impulsionar sua operação na era digital<span className="text-[#00ade0]">.</span></>
+            <>use <span className="text-[var(--primary-color)]">tecnologia</span> segura, escalável e inteligente para impulsionar sua operação na era digital<span className="text-[var(--primary-color)]">.</span></>
           ) :
           language === 'en' ? (
             pageContent?.content && JSON.parse(pageContent.content).heroTitle_en || 
-            <>use secure, scalable and intelligent <span className="text-[#00ade0]">technology</span> to boost your operation in the digital era<span className="text-[#00ade0]">.</span></>
+            <>use secure, scalable and intelligent <span className="text-[var(--primary-color)]">technology</span> to boost your operation in the digital era<span className="text-[var(--primary-color)]">.</span></>
           ) :
           language === 'es' ? (
             pageContent?.content && JSON.parse(pageContent.content).heroTitle_es || 
-            <>use <span className="text-[#00ade0]">tecnología</span> segura, escalable e inteligente para impulsar su operación en la era digital<span className="text-[#00ade0]">.</span></>
+            <>use <span className="text-[var(--primary-color)]">tecnología</span> segura, escalable e inteligente para impulsar su operación en la era digital<span className="text-[var(--primary-color)]">.</span></>
           ) :
-          <>use <span className="text-[#00ade0]">tecnologia</span> segura, escalável e inteligente para impulsionar sua operação na era digital<span className="text-[#00ade0]">.</span></>
+          <>use <span className="text-[var(--primary-color)]">tecnologia</span> segura, escalável e inteligente para impulsionar sua operação na era digital<span className="text-[var(--primary-color)]">.</span></>
         }
         subtitle={pageContent?.content && JSON.parse(pageContent.content).heroSubtitle || "arquitetura modular em infraestrutura, segurança e software para acelerar operações digitais com confiabilidade e velocidade"}
         ctaText1={

--- a/client/src/site/ness/services/AutoOpsPage.tsx
+++ b/client/src/site/ness/services/AutoOpsPage.tsx
@@ -38,7 +38,7 @@ export default function NessAutoOpsPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center min-h-screen">
-          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );
@@ -49,7 +49,7 @@ export default function NessAutoOpsPage() {
     if (name.startsWith('n.')) {
       return (
         <span className="font-['Montserrat'] font-normal">
-          n<span className="text-[#00ade0]">.</span>{name.substring(2)}
+          n<span className="text-[var(--primary-color)]">.</span>{name.substring(2)}
         </span>
       );
     }
@@ -164,7 +164,7 @@ export default function NessAutoOpsPage() {
             <h2 className="text-2xl font-['Montserrat'] font-normal mb-8">
               {content.cta.title}
             </h2>
-            <Link href="/site/ness/contact" className="inline-block bg-[#00ade0] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
+            <Link href="/site/ness/contact" className="inline-block bg-[var(--primary-color)] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
               {content.cta.button}
             </Link>
           </div>

--- a/client/src/site/ness/services/CrisisOpsPage.tsx
+++ b/client/src/site/ness/services/CrisisOpsPage.tsx
@@ -38,7 +38,7 @@ export default function NessCrisisOpsPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center min-h-screen">
-          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );
@@ -49,7 +49,7 @@ export default function NessCrisisOpsPage() {
     if (name.startsWith('n.')) {
       return (
         <span className="font-['Montserrat'] font-normal">
-          n<span className="text-[#00ade0]">.</span>{name.substring(2)}
+          n<span className="text-[var(--primary-color)]">.</span>{name.substring(2)}
         </span>
       );
     }
@@ -164,7 +164,7 @@ export default function NessCrisisOpsPage() {
             <h2 className="text-2xl font-['Montserrat'] font-normal mb-8">
               {content.cta.title}
             </h2>
-            <Link href="/site/ness/contact" className="inline-block bg-[#00ade0] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
+            <Link href="/site/ness/contact" className="inline-block bg-[var(--primary-color)] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
               {content.cta.button}
             </Link>
           </div>

--- a/client/src/site/ness/services/DevArchPage.tsx
+++ b/client/src/site/ness/services/DevArchPage.tsx
@@ -38,7 +38,7 @@ export default function NessDevArchPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center min-h-screen">
-          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );
@@ -49,7 +49,7 @@ export default function NessDevArchPage() {
     if (name.startsWith('n.')) {
       return (
         <span className="font-['Montserrat'] font-normal">
-          n<span className="text-[#00ade0]">.</span>{name.substring(2)}
+          n<span className="text-[var(--primary-color)]">.</span>{name.substring(2)}
         </span>
       );
     }
@@ -164,7 +164,7 @@ export default function NessDevArchPage() {
             <h2 className="text-2xl font-['Montserrat'] font-normal mb-8">
               {content.cta.title}
             </h2>
-            <Link href="/site/ness/contact" className="inline-block bg-[#00ade0] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
+            <Link href="/site/ness/contact" className="inline-block bg-[var(--primary-color)] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
               {content.cta.button}
             </Link>
           </div>

--- a/client/src/site/ness/services/InfraOpsPage.tsx
+++ b/client/src/site/ness/services/InfraOpsPage.tsx
@@ -38,7 +38,7 @@ export default function NessInfraOpsPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center min-h-screen">
-          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );
@@ -49,7 +49,7 @@ export default function NessInfraOpsPage() {
     if (name.startsWith('n.')) {
       return (
         <span className="font-['Montserrat'] font-normal">
-          n<span className="text-[#00ade0]">.</span>{name.substring(2)}
+          n<span className="text-[var(--primary-color)]">.</span>{name.substring(2)}
         </span>
       );
     }
@@ -164,7 +164,7 @@ export default function NessInfraOpsPage() {
             <h2 className="text-2xl font-['Montserrat'] font-normal mb-8">
               {content.cta.title}
             </h2>
-            <Link href="/site/ness/contact" className="inline-block bg-[#00ade0] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
+            <Link href="/site/ness/contact" className="inline-block bg-[var(--primary-color)] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
               {content.cta.button}
             </Link>
           </div>

--- a/client/src/site/ness/services/PrivacyPage.tsx
+++ b/client/src/site/ness/services/PrivacyPage.tsx
@@ -38,7 +38,7 @@ export default function NessPrivacyPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center min-h-screen">
-          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );
@@ -49,7 +49,7 @@ export default function NessPrivacyPage() {
     if (name.startsWith('n.')) {
       return (
         <span className="font-['Montserrat'] font-normal">
-          n<span className="text-[#00ade0]">.</span>{name.substring(2)}
+          n<span className="text-[var(--primary-color)]">.</span>{name.substring(2)}
         </span>
       );
     }
@@ -164,7 +164,7 @@ export default function NessPrivacyPage() {
             <h2 className="text-2xl font-['Montserrat'] font-normal mb-8">
               {content.cta.title}
             </h2>
-            <Link href="/site/ness/contact" className="inline-block bg-[#00ade0] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
+            <Link href="/site/ness/contact" className="inline-block bg-[var(--primary-color)] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
               {content.cta.button}
             </Link>
           </div>

--- a/client/src/site/ness/services/SecOpsPage.tsx
+++ b/client/src/site/ness/services/SecOpsPage.tsx
@@ -38,7 +38,7 @@ export default function NessSecOpsPage() {
     return (
       <SiteLayout>
         <div className="flex justify-center items-center min-h-screen">
-          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[#00ade0]"></div>
+          <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--primary-color)]"></div>
         </div>
       </SiteLayout>
     );
@@ -49,7 +49,7 @@ export default function NessSecOpsPage() {
     if (name.startsWith('n.')) {
       return (
         <span className="font-['Montserrat'] font-normal">
-          n<span className="text-[#00ade0]">.</span>{name.substring(2)}
+          n<span className="text-[var(--primary-color)]">.</span>{name.substring(2)}
         </span>
       );
     }
@@ -164,7 +164,7 @@ export default function NessSecOpsPage() {
             <h2 className="text-2xl font-['Montserrat'] font-normal mb-8">
               {content.cta.title}
             </h2>
-            <Link href="/site/ness/contact" className="inline-block bg-[#00ade0] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
+            <Link href="/site/ness/contact" className="inline-block bg-[var(--primary-color)] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 rounded-sm font-['Montserrat'] lowercase">
               {content.cta.button}
             </Link>
           </div>

--- a/client/src/site/trustness/AboutPage.tsx
+++ b/client/src/site/trustness/AboutPage.tsx
@@ -65,7 +65,7 @@ export default function TrustnessAboutPage() {
           <div className="container mx-auto px-4 relative z-10">
             <div className="max-w-3xl mx-auto text-center">
               <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-6 lowercase">
-                trustness<span className="text-[#005fa3]">.</span>
+                trustness<span className="text-[var(--primary-color)]">.</span>
               </h1>
               <p className="text-xl text-gray-300 mb-8">
                 {defaultContent.heroSubtitle}
@@ -81,7 +81,7 @@ export default function TrustnessAboutPage() {
               <h2 className="font-['Montserrat'] font-normal text-2xl md:text-3xl mb-6 text-center lowercase">
                 <span className="font-normal">
                   {language === 'pt' ? 'somos a' : language === 'es' ? 'somos' : 'we are'}
-                </span> <span className="text-black font-normal">trustness<span className="text-[#005fa3]">.</span></span>
+                </span> <span className="text-black font-normal">trustness<span className="text-[var(--primary-color)]">.</span></span>
               </h2>
               
               <div className="prose prose-base mx-auto text-gray-700 lowercase">
@@ -91,7 +91,7 @@ export default function TrustnessAboutPage() {
                     .map((item, index, arr) => (
                       <>
                         {item}
-                        {index < arr.length - 1 && <span className="text-[#005fa3]"> • </span>}
+                        {index < arr.length - 1 && <span className="text-[var(--primary-color)]"> • </span>}
                       </>
                     ))
                   }
@@ -116,7 +116,7 @@ export default function TrustnessAboutPage() {
             
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               {/* Vision */}
-              <div className="bg-[#21212b] p-8 rounded-sm border-l-2 border-[#005fa3]">
+              <div className="bg-[#21212b] p-8 rounded-sm border-l-2 border-[var(--primary-color)]">
                 <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
                   {defaultContent.values.vision.title}
                 </h3>
@@ -126,7 +126,7 @@ export default function TrustnessAboutPage() {
               </div>
               
               {/* Mission */}
-              <div className="bg-[#21212b] p-8 rounded-sm border-l-2 border-[#005fa3]">
+              <div className="bg-[#21212b] p-8 rounded-sm border-l-2 border-[var(--primary-color)]">
                 <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
                   {defaultContent.values.mission.title}
                 </h3>
@@ -136,7 +136,7 @@ export default function TrustnessAboutPage() {
               </div>
               
               {/* Values */}
-              <div className="bg-[#21212b] p-8 rounded-sm border-l-2 border-[#005fa3]">
+              <div className="bg-[#21212b] p-8 rounded-sm border-l-2 border-[var(--primary-color)]">
                 <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-white">
                   {defaultContent.values.values.title}
                 </h3>
@@ -171,7 +171,7 @@ export default function TrustnessAboutPage() {
             <div className="max-w-5xl mx-auto">
               <div className="relative">
                 {/* Linha do tempo vertical */}
-                <div className="absolute left-1/2 transform -translate-x-1/2 h-full w-px bg-[#00ade0] opacity-50"></div>
+                <div className="absolute left-1/2 transform -translate-x-1/2 h-full w-px bg-[var(--primary-color)] opacity-50"></div>
                 
                 {/* Eventos na linha do tempo */}
                 {Object.entries(defaultContent.timelineEvents).map(([year, description], index) => (
@@ -180,7 +180,7 @@ export default function TrustnessAboutPage() {
                       <div className={`${index % 2 === 0 ? 'text-right' : 'text-left'}`}>
                         <span className="text-2xl font-['Montserrat'] font-medium text-gray-900">
                           {year.includes('.') ? year.split('.')[0] : year}
-                          {year.includes('.') && <span className="text-[#00ade0] text-sm">.{year.split('.')[1]}</span>}
+                          {year.includes('.') && <span className="text-[var(--primary-color)] text-sm">.{year.split('.')[1]}</span>}
                         </span>
                         <p className="mt-2 text-gray-700 lowercase">
                           {description}
@@ -188,7 +188,7 @@ export default function TrustnessAboutPage() {
                       </div>
                     </div>
                     
-                    <div className="absolute left-1/2 transform -translate-x-1/2 w-4 h-4 bg-[#00ade0] rounded-full mt-1"></div>
+                    <div className="absolute left-1/2 transform -translate-x-1/2 w-4 h-4 bg-[var(--primary-color)] rounded-full mt-1"></div>
                     
                     <div className="w-1/2 px-6"></div>
                   </div>
@@ -203,16 +203,16 @@ export default function TrustnessAboutPage() {
           <div className="container mx-auto px-4 text-center">
             <h2 className="text-3xl font-['Montserrat'] font-normal mb-8 lowercase">
               {language === 'pt' 
-                ? <>quer saber mais sobre a <span className="font-normal">trustness<span className="text-[#00ade0]">.</span></span>?</> 
+                ? <>quer saber mais sobre a <span className="font-normal">trustness<span className="text-[var(--primary-color)]">.</span></span>?</> 
                 : language === 'en'
-                  ? <>want to know more about <span className="font-normal">trustness<span className="text-[#00ade0]">.</span></span>?</>
-                  : <>¿quieres saber más sobre <span className="font-normal">trustness<span className="text-[#00ade0]">.</span></span>?</>
+                  ? <>want to know more about <span className="font-normal">trustness<span className="text-[var(--primary-color)]">.</span></span>?</>
+                  : <>¿quieres saber más sobre <span className="font-normal">trustness<span className="text-[var(--primary-color)]">.</span></span>?</>
               }
             </h2>
             
             <a 
               href="/site/trustness/contact" 
-              className="inline-block bg-[#00ade0] hover:bg-opacity-90 text-white py-3 px-8 rounded lowercase transition duration-300"
+              className="inline-block bg-[var(--primary-color)] hover:bg-opacity-90 text-white py-3 px-8 rounded lowercase transition duration-300"
             >
               {defaultContent.cta.button}
             </a>

--- a/client/src/site/trustness/HomePage.tsx
+++ b/client/src/site/trustness/HomePage.tsx
@@ -48,7 +48,7 @@ export default function TrustnessHomePage() {
         <div className="container mx-auto px-4 relative z-10">
           <div className="max-w-3xl mx-auto text-center">
             <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-6 lowercase">
-              trustness<span className="text-[#00ade0]">.</span>
+              trustness<span className="text-[var(--primary-color)]">.</span>
             </h1>
             <p className="text-xl text-gray-300 mb-8">
               {language === 'pt' && (pageContent?.content?.heroSubtitle || 
@@ -61,7 +61,7 @@ export default function TrustnessHomePage() {
             <div className="flex flex-col sm:flex-row justify-center gap-4">
               <a
                 href="#what-we-do"
-                className="bg-[#00ade0] hover:bg-opacity-90 text-white px-6 py-3 rounded lowercase"
+                className="bg-[var(--primary-color)] hover:bg-opacity-90 text-white px-6 py-3 rounded lowercase"
               >
                 {language === 'pt' && 'nossos serviços'}
                 {language === 'en' && 'our services'}
@@ -69,7 +69,7 @@ export default function TrustnessHomePage() {
               </a>
               <a
                 href="/site/trustness/contact"
-                className="border border-[#00ade0] text-white hover:bg-white hover:bg-opacity-10 px-6 py-3 rounded lowercase"
+                className="border border-[var(--primary-color)] text-white hover:bg-white hover:bg-opacity-10 px-6 py-3 rounded lowercase"
               >
                 {language === 'pt' && 'fale conosco'}
                 {language === 'en' && 'contact us'}
@@ -104,7 +104,7 @@ export default function TrustnessHomePage() {
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">assessment</h3>
                   </div>
                   <p className="mb-4">
-                    <span className="text-[#005fa3] font-semibold text-lg block mb-2">você sabe como vai sua segurança?</span>
+                    <span className="text-[var(--primary-color)] font-semibold text-lg block mb-2">você sabe como vai sua segurança?</span>
                     <span className="text-gray-700">
                       na trustness, avaliamos, auditamos e estruturamos práticas que sustentam a segurança, a privacidade e a conformidade regulatória.
                     </span>
@@ -119,7 +119,7 @@ export default function TrustnessHomePage() {
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">certificações</h3>
                   </div>
                   <p className="mb-4">
-                    <span className="text-[#005fa3] font-semibold text-lg block mb-2">vai se certificar ISO 27001, ou outra certificação?</span>
+                    <span className="text-[var(--primary-color)] font-semibold text-lg block mb-2">vai se certificar ISO 27001, ou outra certificação?</span>
                     <span className="text-gray-700">
                       atuamos também como auditores externos, avaliando a aderência da organização a normas e requisitos específicos — antes de uma certificação ou como parte de uma estratégia contínua de conformidade.
                     </span>
@@ -131,7 +131,7 @@ export default function TrustnessHomePage() {
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">privacidade</h3>
                   </div>
                   <p className="mb-4">
-                    <span className="text-[#005fa3] font-semibold text-lg block mb-2">precisa se adequar à LGPD, ou outra norma de privacidade?</span>
+                    <span className="text-[var(--primary-color)] font-semibold text-lg block mb-2">precisa se adequar à LGPD, ou outra norma de privacidade?</span>
                     <span className="text-gray-700">
                       conduzimos projetos completos de adequação à LGPD, GDPR, HIPAA e outras regulamentações de privacidade, com mapeamento de dados, implantação de controles e apoio contínuo à gestão.
                     </span>
@@ -153,7 +153,7 @@ export default function TrustnessHomePage() {
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">assessment</h3>
                   </div>
                   <p className="mb-4">
-                    <span className="text-[#005fa3] font-semibold text-lg block mb-2">do you know how your security is doing?</span>
+                    <span className="text-[var(--primary-color)] font-semibold text-lg block mb-2">do you know how your security is doing?</span>
                     <span className="text-gray-700">
                       at trustness, we assess, audit, and structure practices that support security, privacy, and regulatory compliance.
                     </span>
@@ -168,7 +168,7 @@ export default function TrustnessHomePage() {
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">certifications</h3>
                   </div>
                   <p className="mb-4">
-                    <span className="text-[#005fa3] font-semibold text-lg block mb-2">need ISO 27001 certification or other security standards?</span>
+                    <span className="text-[var(--primary-color)] font-semibold text-lg block mb-2">need ISO 27001 certification or other security standards?</span>
                     <span className="text-gray-700">
                       we also act as external auditors, evaluating the organization's adherence to specific standards and requirements — before certification or as part of an ongoing compliance strategy.
                     </span>
@@ -180,7 +180,7 @@ export default function TrustnessHomePage() {
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">privacy</h3>
                   </div>
                   <p className="mb-4">
-                    <span className="text-[#005fa3] font-semibold text-lg block mb-2">need to comply with GDPR, LGPD or other privacy laws?</span>
+                    <span className="text-[var(--primary-color)] font-semibold text-lg block mb-2">need to comply with GDPR, LGPD or other privacy laws?</span>
                     <span className="text-gray-700">
                       we conduct complete compliance projects for GDPR, LGPD, HIPAA and other privacy regulations, with data mapping, control implementation and continuous management support.
                     </span>
@@ -202,7 +202,7 @@ export default function TrustnessHomePage() {
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">assessment</h3>
                   </div>
                   <p className="mb-4">
-                    <span className="text-[#005fa3] font-semibold text-lg block mb-2">¿sabes cómo va tu seguridad?</span>
+                    <span className="text-[var(--primary-color)] font-semibold text-lg block mb-2">¿sabes cómo va tu seguridad?</span>
                     <span className="text-gray-700">
                       en trustness, evaluamos, auditamos y estructuramos prácticas que sustentan la seguridad, la privacidad y el cumplimiento normativo.
                     </span>
@@ -217,7 +217,7 @@ export default function TrustnessHomePage() {
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">certificaciones</h3>
                   </div>
                   <p className="mb-4">
-                    <span className="text-[#005fa3] font-semibold text-lg block mb-2">¿necesita certificarse en ISO 27001 u otros estándares de seguridad?</span>
+                    <span className="text-[var(--primary-color)] font-semibold text-lg block mb-2">¿necesita certificarse en ISO 27001 u otros estándares de seguridad?</span>
                     <span className="text-gray-700">
                       también actuamos como auditores externos, evaluando la adhesión de la organización a normas y requisitos específicos — antes de una certificación o como parte de una estrategia continua de cumplimiento.
                     </span>
@@ -229,7 +229,7 @@ export default function TrustnessHomePage() {
                     <h3 className="text-xl font-['Montserrat'] font-normal mb-4 text-gray-800">privacidad</h3>
                   </div>
                   <p className="mb-4">
-                    <span className="text-[#005fa3] font-semibold text-lg block mb-2">¿necesita cumplir con GDPR, LGPD u otras leyes de privacidad?</span>
+                    <span className="text-[var(--primary-color)] font-semibold text-lg block mb-2">¿necesita cumplir con GDPR, LGPD u otras leyes de privacidad?</span>
                     <span className="text-gray-700">
                       realizamos proyectos completos de adecuación a GDPR, LGPD, HIPAA y otras regulaciones de privacidad, con mapeo de datos, implementación de controles y apoyo continuo a la gestión.
                     </span>
@@ -263,7 +263,7 @@ export default function TrustnessHomePage() {
             <div className="bg-[#21212b] rounded p-6 border border-gray-800 shadow-sm hover:shadow-md transition-shadow duration-300 text-center">
               <h3 className="mb-4">
                 <span className="font-['Montserrat'] font-medium text-lg text-white">
-                  <span className="text-[#005fa3]">.</span>assessment
+                  <span className="text-[var(--primary-color)]">.</span>assessment
                 </span>
               </h3>
               <p className="text-gray-300 text-sm mb-6 lowercase">
@@ -272,7 +272,7 @@ export default function TrustnessHomePage() {
               <div className="text-center">
                 <a 
                   href="/site/trustness/services/assessment" 
-                  className="text-gray-300 hover:text-[#005fa3] border border-gray-700 hover:border-[#005fa3] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
+                  className="text-gray-300 hover:text-[var(--primary-color)] border border-gray-700 hover:border-[var(--primary-color)] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
                 >
                   saiba mais
                 </a>
@@ -283,7 +283,7 @@ export default function TrustnessHomePage() {
             <div className="bg-[#21212b] rounded p-6 border border-gray-800 shadow-sm hover:shadow-md transition-shadow duration-300 text-center">
               <h3 className="mb-4">
                 <span className="font-['Montserrat'] font-medium text-lg text-white">
-                  <span className="text-[#005fa3]">.</span>conformity
+                  <span className="text-[var(--primary-color)]">.</span>conformity
                 </span>
               </h3>
               <p className="text-gray-300 text-sm mb-6 lowercase">
@@ -292,7 +292,7 @@ export default function TrustnessHomePage() {
               <div className="text-center">
                 <a 
                   href="/site/trustness/services/conformity" 
-                  className="text-gray-300 hover:text-[#005fa3] border border-gray-700 hover:border-[#005fa3] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
+                  className="text-gray-300 hover:text-[var(--primary-color)] border border-gray-700 hover:border-[var(--primary-color)] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
                 >
                   saiba mais
                 </a>
@@ -303,7 +303,7 @@ export default function TrustnessHomePage() {
             <div className="bg-[#21212b] rounded p-6 border border-gray-800 shadow-sm hover:shadow-md transition-shadow duration-300 text-center">
               <h3 className="mb-4">
                 <span className="font-['Montserrat'] font-medium text-lg text-white">
-                  <span className="text-[#005fa3]">.</span>privacy
+                  <span className="text-[var(--primary-color)]">.</span>privacy
                 </span>
               </h3>
               <p className="text-gray-300 text-sm mb-6 lowercase">
@@ -312,7 +312,7 @@ export default function TrustnessHomePage() {
               <div className="text-center">
                 <a 
                   href="/site/trustness/services/privacy" 
-                  className="text-gray-300 hover:text-[#005fa3] border border-gray-700 hover:border-[#005fa3] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
+                  className="text-gray-300 hover:text-[var(--primary-color)] border border-gray-700 hover:border-[var(--primary-color)] py-2 px-4 text-sm font-normal transition-colors duration-300 inline-block lowercase rounded-sm"
                 >
                   saiba mais
                 </a>

--- a/client/src/site/trustness/services/AssessmentPage.tsx
+++ b/client/src/site/trustness/services/AssessmentPage.tsx
@@ -61,7 +61,7 @@ export default function TrustnessAssessmentPage() {
           <div className="container mx-auto px-4 relative z-10">
             <div className="max-w-3xl">
               <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-6 lowercase">
-                <span className="text-[#005fa3]">.</span>assessment
+                <span className="text-[var(--primary-color)]">.</span>assessment
               </h1>
               <p className="text-xl text-gray-300 mb-8">
                 {defaultContent.heroSubtitle}
@@ -85,7 +85,7 @@ export default function TrustnessAssessmentPage() {
               <ul className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
                 {defaultContent.features?.map((feature, index) => (
                   <li key={index} className="flex items-start">
-                    <span className="text-[#005fa3] mr-2">•</span>
+                    <span className="text-[var(--primary-color)] mr-2">•</span>
                     <span className="text-gray-700 lowercase">{feature}</span>
                   </li>
                 ))}
@@ -106,7 +106,7 @@ export default function TrustnessAssessmentPage() {
                 {defaultContent.methodology}
               </p>
               
-              <div className="bg-white p-8 rounded-sm border-l-2 border-[#005fa3] shadow-sm">
+              <div className="bg-white p-8 rounded-sm border-l-2 border-[var(--primary-color)] shadow-sm">
                 <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-gray-800">
                   {language === 'pt' ? 'benefícios' : language === 'en' ? 'benefits' : 'beneficios'}
                 </h3>
@@ -114,7 +114,7 @@ export default function TrustnessAssessmentPage() {
                 <ul className="space-y-3">
                   {defaultContent.benefits?.map((benefit, index) => (
                     <li key={index} className="flex items-start">
-                      <span className="text-[#005fa3] mr-2">•</span>
+                      <span className="text-[var(--primary-color)] mr-2">•</span>
                       <span className="text-gray-700 lowercase">{benefit}</span>
                     </li>
                   ))}
@@ -137,7 +137,7 @@ export default function TrustnessAssessmentPage() {
             </h2>
             <a 
               href={language === 'pt' ? "/site/trustness/contact" : language === 'en' ? "/site/trustness/contact" : "/site/trustness/contact"} 
-              className="bg-transparent hover:bg-[#00ade0] text-white border border-[#00ade0] hover:border-transparent px-8 py-3 rounded lowercase inline-block transition-colors duration-300"
+              className="bg-transparent hover:bg-[var(--primary-color)] text-white border border-[var(--primary-color)] hover:border-transparent px-8 py-3 rounded lowercase inline-block transition-colors duration-300"
             >
               {language === 'pt' ? 'fale conosco' : language === 'en' ? 'contact us' : 'contáctenos'}
             </a>

--- a/client/src/site/trustness/services/ConformityPage.tsx
+++ b/client/src/site/trustness/services/ConformityPage.tsx
@@ -62,7 +62,7 @@ export default function TrustnessConformityPage() {
           <div className="container mx-auto px-4 relative z-10">
             <div className="max-w-3xl">
               <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-6 lowercase">
-                <span className="text-[#005fa3]">.</span>conformity
+                <span className="text-[var(--primary-color)]">.</span>conformity
               </h1>
               <p className="text-xl text-gray-300 mb-8">
                 {defaultContent.heroSubtitle}
@@ -86,7 +86,7 @@ export default function TrustnessConformityPage() {
               <ul className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
                 {defaultContent.features?.map((feature, index) => (
                   <li key={index} className="flex items-start">
-                    <span className="text-[#005fa3] mr-2">•</span>
+                    <span className="text-[var(--primary-color)] mr-2">•</span>
                     <span className="text-gray-700 lowercase">{feature}</span>
                   </li>
                 ))}
@@ -107,7 +107,7 @@ export default function TrustnessConformityPage() {
                 {defaultContent.methodology}
               </p>
               
-              <div className="bg-white p-8 rounded-sm border-l-2 border-[#005fa3] shadow-sm">
+              <div className="bg-white p-8 rounded-sm border-l-2 border-[var(--primary-color)] shadow-sm">
                 <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-gray-800">
                   {language === 'pt' ? 'benefícios' : language === 'en' ? 'benefits' : 'beneficios'}
                 </h3>
@@ -115,7 +115,7 @@ export default function TrustnessConformityPage() {
                 <ul className="space-y-3">
                   {defaultContent.benefits?.map((benefit, index) => (
                     <li key={index} className="flex items-start">
-                      <span className="text-[#005fa3] mr-2">•</span>
+                      <span className="text-[var(--primary-color)] mr-2">•</span>
                       <span className="text-gray-700 lowercase">{benefit}</span>
                     </li>
                   ))}
@@ -138,7 +138,7 @@ export default function TrustnessConformityPage() {
             </h2>
             <a 
               href={language === 'pt' ? "/site/trustness/contact" : language === 'en' ? "/site/trustness/contact" : "/site/trustness/contact"} 
-              className="bg-transparent hover:bg-[#00ade0] text-white border border-[#00ade0] hover:border-transparent px-8 py-3 rounded lowercase inline-block transition-colors duration-300"
+              className="bg-transparent hover:bg-[var(--primary-color)] text-white border border-[var(--primary-color)] hover:border-transparent px-8 py-3 rounded lowercase inline-block transition-colors duration-300"
             >
               {language === 'pt' ? 'fale conosco' : language === 'en' ? 'contact us' : 'contáctenos'}
             </a>

--- a/client/src/site/trustness/services/PrivacyPage.tsx
+++ b/client/src/site/trustness/services/PrivacyPage.tsx
@@ -60,7 +60,7 @@ export default function TrustnessPrivacyPage() {
           <div className="container mx-auto px-4 relative z-10">
             <div className="max-w-3xl">
               <h1 className="text-4xl md:text-5xl font-['Montserrat'] font-normal mb-6 lowercase">
-                <span className="text-[#005fa3]">.</span>privacy
+                <span className="text-[var(--primary-color)]">.</span>privacy
               </h1>
               <p className="text-xl text-gray-300 mb-8">
                 {defaultContent.heroSubtitle}
@@ -84,7 +84,7 @@ export default function TrustnessPrivacyPage() {
               <ul className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
                 {defaultContent.features?.map((feature, index) => (
                   <li key={index} className="flex items-start">
-                    <span className="text-[#005fa3] mr-2">•</span>
+                    <span className="text-[var(--primary-color)] mr-2">•</span>
                     <span className="text-gray-700 lowercase">{feature}</span>
                   </li>
                 ))}
@@ -105,7 +105,7 @@ export default function TrustnessPrivacyPage() {
                 {defaultContent.methodology}
               </p>
               
-              <div className="bg-white p-8 rounded-sm border-l-2 border-[#005fa3] shadow-sm">
+              <div className="bg-white p-8 rounded-sm border-l-2 border-[var(--primary-color)] shadow-sm">
                 <h3 className="text-xl font-['Montserrat'] font-normal mb-4 lowercase text-gray-800">
                   {language === 'pt' ? 'benefícios' : language === 'en' ? 'benefits' : 'beneficios'}
                 </h3>
@@ -113,7 +113,7 @@ export default function TrustnessPrivacyPage() {
                 <ul className="space-y-3">
                   {defaultContent.benefits?.map((benefit, index) => (
                     <li key={index} className="flex items-start">
-                      <span className="text-[#005fa3] mr-2">•</span>
+                      <span className="text-[var(--primary-color)] mr-2">•</span>
                       <span className="text-gray-700 lowercase">{benefit}</span>
                     </li>
                   ))}
@@ -136,7 +136,7 @@ export default function TrustnessPrivacyPage() {
             </h2>
             <a 
               href={language === 'pt' ? "/site/trustness/contact" : language === 'en' ? "/site/trustness/contact" : "/site/trustness/contact"} 
-              className="bg-transparent hover:bg-[#00ade0] text-white border border-[#00ade0] hover:border-transparent px-8 py-3 rounded lowercase inline-block transition-colors duration-300"
+              className="bg-transparent hover:bg-[var(--primary-color)] text-white border border-[var(--primary-color)] hover:border-transparent px-8 py-3 rounded lowercase inline-block transition-colors duration-300"
             >
               {language === 'pt' ? 'fale conosco' : language === 'en' ? 'contact us' : 'contáctenos'}
             </a>


### PR DESCRIPTION
## Summary
- replace hardcoded color hex codes with CSS variables
- update site components to reference `--primary-color` and `--secondary-color`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_68406b1f0a188330a5822aa6845ec200