### PR TITLE
Update hero texts for ness service pages

### DIFF
--- a/client/src/site/ness/translations/services/autoops.ts
+++ b/client/src/site/ness/translations/services/autoops.ts
@@ -3,8 +3,8 @@ import { Language } from '@/lib/i18n';
 const defaultContent: Record<Language, any> = {
     pt: {
       title: 'n.AutoOps',
-      description: 'automação inteligente de processos com IA',
-      intro: 'o n.AutoOps da ness combina tecnologias de automação com inteligência artificial para transformar processos operacionais, aumentar eficiência e reduzir custos, permitindo que as equipes foquem em atividades estratégicas.',
+      description: 'Otimize seus processos com automação inteligente.',
+      intro: 'Tecnologia para produtividade real, conectada à sua operação.',
       sections: [
         {
           title: 'avaliação de processos',
@@ -50,8 +50,8 @@ const defaultContent: Record<Language, any> = {
     },
     en: {
       title: 'n.AutoOps',
-      description: 'intelligent process automation with AI',
-      intro: 'ness\'s n.AutoOps combines automation technologies with artificial intelligence to transform operational processes, increase efficiency, and reduce costs, allowing teams to focus on strategic activities.',
+      description: 'Optimize your processes with intelligent automation.',
+      intro: 'Technology for real productivity, connected to your operation.',
       sections: [
         {
           title: 'process assessment',
@@ -97,8 +97,8 @@ const defaultContent: Record<Language, any> = {
     },
     es: {
       title: 'n.AutoOps',
-      description: 'automatización inteligente de procesos con IA',
-      intro: 'el n.AutoOps de ness combina tecnologías de automatización con inteligencia artificial para transformar procesos operacionales, aumentar eficiencia y reducir costos, permitiendo que los equipos se enfoquen en actividades estratégicas.',
+      description: 'Optimice sus procesos con automatización inteligente.',
+      intro: 'Tecnología para productividad real, conectada a su operación.',
       sections: [
         {
           title: 'evaluación de procesos',

--- a/client/src/site/ness/translations/services/devarch.ts
+++ b/client/src/site/ness/translations/services/devarch.ts
@@ -4,7 +4,7 @@ const defaultContent: Record<Language, any> = {
     pt: {
       title: 'n.DevArch',
       description: 'fundamentos sólidos para desenvolvimento com arquitetura e IA',
-      intro: 'o n.DevArch da ness cria bases sólidas para o desenvolvimento de software com foco em arquitetura moderna, integrando inteligência artificial para elevar a qualidade, eficiência e escalabilidade dos sistemas.',
+      intro: 'Desenvolvimento orientado por arquitetura e boas práticas de segurança.',
       sections: [
         {
           title: 'arquitetura moderna',
@@ -51,7 +51,7 @@ const defaultContent: Record<Language, any> = {
     en: {
       title: 'n.DevArch',
       description: 'solid foundations for development with architecture and AI',
-      intro: 'ness\'s n.DevArch creates solid foundations for software development focusing on modern architecture, integrating artificial intelligence to elevate the quality, efficiency, and scalability of systems.',
+      intro: 'Development driven by architecture and security best practices.',
       sections: [
         {
           title: 'modern architecture',
@@ -98,7 +98,7 @@ const defaultContent: Record<Language, any> = {
     es: {
       title: 'n.DevArch',
       description: 'fundamentos sólidos para desarrollo con arquitectura e IA',
-      intro: 'el n.DevArch de ness crea bases sólidas para el desarrollo de software con enfoque en arquitectura moderna, integrando inteligencia artificial para elevar la calidad, eficiencia y escalabilidad de los sistemas.',
+      intro: 'Desarrollo orientado por arquitectura y buenas prácticas de seguridad.',
       sections: [
         {
           title: 'arquitectura moderna',

--- a/client/src/site/ness/translations/services/infraops.ts
+++ b/client/src/site/ness/translations/services/infraops.ts
@@ -3,8 +3,8 @@ import { Language } from '@/lib/i18n';
 const defaultContent: Record<Language, any> = {
     pt: {
       title: 'n.InfraOps',
-      description: 'gestão moderna de infraestrutura com alta disponibilidade',
-      intro: 'o n.InfraOps da ness oferece um modelo modular e integrado para gerenciamento de infraestrutura, garantindo operações confiáveis, alta disponibilidade e escalabilidade para ambientes corporativos de qualquer porte.',
+      description: 'gestão de infraestrutura com alta disponibilidade',
+      intro: 'Gerenciamos redes, servidores e nuvem com foco em desempenho e confiabilidade.',
       sections: [
         {
           title: 'arquitetura de nuvem',
@@ -50,8 +50,8 @@ const defaultContent: Record<Language, any> = {
     },
     en: {
       title: 'n.InfraOps',
-      description: 'modern infrastructure management with high availability',
-      intro: 'ness\'s n.InfraOps offers a modular and integrated model for infrastructure management, ensuring reliable operations, high availability, and scalability for corporate environments of any size.',
+      description: 'infrastructure management with high availability',
+      intro: 'We manage networks, servers and cloud with a focus on performance and reliability.',
       sections: [
         {
           title: 'cloud architecture',
@@ -97,8 +97,8 @@ const defaultContent: Record<Language, any> = {
     },
     es: {
       title: 'n.InfraOps',
-      description: 'gestión moderna de infraestructura con alta disponibilidad',
-      intro: 'el n.InfraOps de ness ofrece un modelo modular e integrado para la gestión de infraestructura, garantizando operaciones confiables, alta disponibilidad y escalabilidad para entornos corporativos de cualquier tamaño.',
+      description: 'gestión de infraestructura con alta disponibilidad',
+      intro: 'Gestionamos redes, servidores y nube con enfoque en rendimiento y confiabilidad.',
       sections: [
         {
           title: 'arquitectura de nube',

--- a/client/src/site/ness/translations/services/privacy.ts
+++ b/client/src/site/ness/translations/services/privacy.ts
@@ -3,8 +3,8 @@ import { Language } from '@/lib/i18n';
 const defaultContent: Record<Language, any> = {
     pt: {
       title: 'n.Privacy',
-      description: 'gestão completa de privacidade para conformidade com LGPD/GDPR',
-      intro: 'o n.Privacy da ness oferece uma abordagem estruturada para governança de privacidade e proteção de dados, ajudando organizações a atenderem requisitos regulatórios como LGPD e GDPR, enquanto transformam privacidade em vantagem competitiva.',
+      description: 'Conformidade e privacidade desde a origem.',
+      intro: 'Uma plataforma completa para LGPD, GDPR e gestão de titulares.',
       sections: [
         {
           title: 'diagnóstico e mapeamento',
@@ -50,8 +50,8 @@ const defaultContent: Record<Language, any> = {
     },
     en: {
       title: 'n.Privacy',
-      description: 'complete privacy management for LGPD/GDPR compliance',
-      intro: 'ness\'s n.Privacy offers a structured approach to privacy governance and data protection, helping organizations meet regulatory requirements such as LGPD and GDPR, while transforming privacy into a competitive advantage.',
+      description: 'Compliance and privacy from the source.',
+      intro: 'A complete platform for LGPD, GDPR and data subject management.',
       sections: [
         {
           title: 'diagnosis and mapping',
@@ -97,8 +97,8 @@ const defaultContent: Record<Language, any> = {
     },
     es: {
       title: 'n.Privacy',
-      description: 'gestión completa de privacidad para conformidad con LGPD/GDPR',
-      intro: 'el n.Privacy de ness ofrece un enfoque estructurado para gobernanza de privacidad y protección de datos, ayudando a organizaciones a atender requisitos regulatorios como LGPD y GDPR, mientras transforman la privacidad en ventaja competitiva.',
+      description: 'Conformidad y privacidad desde el origen.',
+      intro: 'Una plataforma completa para LGPD, GDPR y gestión de titulares.',
       sections: [
         {
           title: 'diagnóstico y mapeo',

--- a/client/src/site/ness/translations/services/secops.ts
+++ b/client/src/site/ness/translations/services/secops.ts
@@ -4,7 +4,7 @@ const defaultContent: Record<Language, any> = {
     pt: {
       title: 'n.SecOps',
       description: 'segurança integrada às operações com monitoramento contínuo',
-      intro: 'o n.SecOps da ness integra segurança às operações com foco em monitoramento contínuo e resposta imediata, protegendo sua infraestrutura de forma inteligente e adaptativa.',
+      intro: 'Do SOC à resposta a incidentes, sua resiliência começa com a gente.',
       sections: [
         {
           title: 'monitoramento avançado',
@@ -50,8 +50,8 @@ const defaultContent: Record<Language, any> = {
     },
     en: {
       title: 'n.SecOps',
-      description: 'integrated security operations with continuous monitoring',
-      intro: 'ness\'s n.SecOps integrates security into operations with a focus on continuous monitoring and immediate response, protecting your infrastructure intelligently and adaptively.',
+      description: 'security integrated into operations with continuous monitoring',
+      intro: 'From SOC to incident response, your resilience starts with us.',
       sections: [
         {
           title: 'advanced monitoring',
@@ -98,7 +98,7 @@ const defaultContent: Record<Language, any> = {
     es: {
       title: 'n.SecOps',
       description: 'seguridad integrada a las operaciones con monitoreo continuo',
-      intro: 'el n.SecOps de ness integra seguridad a las operaciones con enfoque en monitoreo continuo y respuesta inmediata, protegiendo su infraestructura de forma inteligente y adaptativa.',
+      intro: 'Del SOC a la respuesta a incidentes, su resiliencia comienza con nosotros.',
       sections: [
         {
           title: 'monitoreo avanzado',


### PR DESCRIPTION
## Summary
- refresh Portuguese texts for service hero sections
- add English and Spanish counterparts

## Testing
- `npm run check` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_68407fc90fe083308c9ba2f30938a522