### PR TITLE
Refine hero styles

### DIFF
--- a/client/src/assets/hero-main.css
+++ b/client/src/assets/hero-main.css
@@ -2,13 +2,15 @@
 .hero-main-content {
   position: relative;
   z-index: 10;
-  text-align: center;
-  max-width: 800px;
+  text-align: left;
+  padding-left: 80px;
+  max-width: 600px;
 }
 
 .hero-main-content h1 {
-  font-size: 3rem;
+  font-size: 2rem; /* 32px */
   font-weight: 500;
+  margin-top: 48px;
   margin-bottom: 1.5rem;
   font-family: 'Montserrat', sans-serif;
   text-transform: lowercase;
@@ -17,11 +19,11 @@
 }
 
 .hero-main-content p {
-  font-size: 1.25rem;
-  line-height: 1.6;
+  font-size: 1rem; /* 16px */
+  line-height: 24px;
   font-weight: 300;
   max-width: 800px;
   text-transform: lowercase;
   margin-bottom: 2rem;
-  color: #ffffff;
+  color: #F5F5F5;
 }

--- a/client/src/components/sections/HeroSection.tsx
+++ b/client/src/components/sections/HeroSection.tsx
@@ -8,8 +8,8 @@ interface HeroSectionProps {
   subtitle: string;
   ctaText1: string;
   ctaUrl1: string;
-  ctaText2: string;
-  ctaUrl2: string;
+  ctaText2?: string;
+  ctaUrl2?: string;
   backgroundImage: string;
 }
 
@@ -31,32 +31,37 @@ export default function HeroSection({
   }, [backgroundImage]);
   
   return (
-    <section className="intro relative flex items-center justify-center overflow-hidden bg-[#121212]" style={{ minHeight: "60vh" }}>
-      
+    <section className="intro relative flex items-center overflow-hidden bg-hero-gradient" style={{ minHeight: '60vh' }}>
+      <div className="hero-vignette-right" />
+
       {/* Content */}
-      <div className="container mx-auto px-4 z-10 flex justify-center items-center h-full">
-        <div className="hero-main-content text-center">
-          <h1 className="text-5xl md:text-6xl lg:text-7xl font-['Montserrat'] font-normal mb-6">
-            <span style={{color: "#ffffff"}}>ness</span><span className="text-[#00ade0]">.</span>
+      <div className="container mx-auto px-4 z-10 flex items-center h-full">
+        <div className="hero-main-content">
+          <h1 className="text-[32px] font-['Montserrat'] font-medium mt-12 mb-6">
+            <span className="text-white">ness</span><span className="text-[#00ade0]">.</span>
           </h1>
-          <div className="text-2xl md:text-3xl lg:text-4xl font-['Montserrat'] font-normal mb-4 text-white lowercase">
+          <div className="text-[48px] font-['Montserrat'] font-normal text-white">
             {title}
           </div>
-        
-          <p className="text-lg md:text-xl lg:text-2xl mb-8 max-w-4xl mx-auto text-white font-['Montserrat'] lowercase">
+
+          <p className="mt-6 text-base leading-6 text-[#F5F5F5] font-['Montserrat']">
             {subtitle}
           </p>
-          
-          <div className="flex flex-col sm:flex-row justify-center space-y-4 sm:space-y-0 sm:space-x-6 mt-8">
-            <Link href={ctaUrl1} className="bg-[#00ade0] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 inline-block lowercase rounded-sm font-['Montserrat']">
-              {ctaText1}
-            </Link>
-            <Link href={ctaUrl2} className="bg-transparent border border-[#00ade0] text-white hover:text-[#00ade0] py-3 px-8 font-normal transition duration-300 inline-block lowercase rounded-sm font-['Montserrat']">
-              {ctaText2}
-            </Link>
-          </div>
+
+          {ctaText1 && ctaUrl1 && (
+            <div className="flex flex-col sm:flex-row justify-start space-y-4 sm:space-y-0 sm:space-x-6 mt-8">
+              <Link href={ctaUrl1} className="bg-[#00ade0] hover:bg-[#0095c4] text-white py-3 px-8 font-normal transition duration-300 inline-block lowercase rounded-sm font-['Montserrat']">
+                {ctaText1}
+              </Link>
+              {ctaText2 && ctaUrl2 && (
+                <Link href={ctaUrl2} className="bg-transparent border border-[#00ade0] text-white hover:text-[#00ade0] py-3 px-8 font-normal transition duration-300 inline-block lowercase rounded-sm font-['Montserrat']">
+                  {ctaText2}
+                </Link>
+              )}
+            </div>
+          )}
         </div>
-        
+
 
       </div>
     </section>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -9,6 +9,20 @@
   .clip-path-polygon {
     clip-path: polygon(0 0, 100% 0, 100% 65%, 0 100%);
   }
+
+  .bg-hero-gradient {
+    background: linear-gradient(to bottom, #0D111E, #131A2A);
+  }
+
+  .hero-vignette-right {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 40%;
+    pointer-events: none;
+    background: linear-gradient(to left, #1F2636, transparent);
+  }
 }
 
 :root {

--- a/client/src/site/forense/HomePage.tsx
+++ b/client/src/site/forense/HomePage.tsx
@@ -40,23 +40,24 @@ export default function ForenseHomePage() {
       canonicalUrl={`https://${siteConfig.domain}`}
     >
       {/* Hero Section */}
-      <section className="intro bg-[#0d1117] text-white relative overflow-hidden flex items-center" style={{ minHeight: "60vh" }}>
-        <div className="container mx-auto px-4 relative">
-          <div className="max-w-3xl mx-auto text-center">
-            <h1 className="mb-3 lowercase">
+      <section className="intro bg-hero-gradient text-white relative overflow-hidden flex items-center" style={{ minHeight: '60vh' }}>
+        <div className="hero-vignette-right" />
+        <div className="container mx-auto px-4 relative flex items-center h-full">
+          <div className="hero-main-content">
+            <h1 className="text-[32px] font-['Montserrat'] font-medium mt-12 mb-3 lowercase">
               forense<span className="text-[#00ade0]">.</span>io
             </h1>
-            <h2 className="lowercase">
+            <h2 className="text-[48px] font-normal text-white lowercase">
               {language === 'pt' && "Especialistas em Forense Digital"}
               {language === 'en' && "Digital Forensic Experts"}
               {language === 'es' && "Expertos en Forense Digital"}
             </h2>
-            <p className="text-xl text-gray-300 mt-8 mb-8">
+            <p className="text-base leading-6 text-[#F5F5F5] mt-6 mb-8">
               {language === 'pt' && "transformamos a evidência digital em resultados concretos, com precisão e segurança"}
               {language === 'en' && "transforming digital evidence into concrete results, with precision and security"}
               {language === 'es' && "transformamos la evidencia digital en resultados concretos, con precisión y seguridad"}
             </p>
-            <div className="flex justify-center">
+            <div className="flex justify-start">
               <a
                 href="/site/forense/contact"
                 className="bg-[#00ade0] hover:bg-opacity-90 text-white px-8 py-3 rounded lowercase transition-all duration-300"

--- a/client/src/site/ness/services/AutoOpsPage.tsx
+++ b/client/src/site/ness/services/AutoOpsPage.tsx
@@ -64,13 +64,14 @@ export default function NessAutoOpsPage() {
       canonicalUrl={`https://${siteConfig.domain}/services/autoops`}
     >
       {/* Hero Section */}
-      <section className="intro bg-[#121212] relative flex items-center justify-center" style={{ minHeight: "60vh" }}>
-        <div className="container mx-auto px-4 z-10">
-          <div className="text-center">
-            <h1 className="text-6xl md:text-7xl font-['Montserrat'] font-normal mb-6 text-white">
+      <section className="intro bg-hero-gradient relative flex items-center overflow-hidden" style={{ minHeight: '60vh' }}>
+        <div className="hero-vignette-right" />
+        <div className="container mx-auto px-4 z-10 flex items-center h-full">
+          <div className="hero-main-content">
+            <h1 className="text-[48px] font-['Montserrat'] font-normal text-white mb-6">
               {formatServiceName(content.title)}
             </h1>
-            <p className="text-xl md:text-2xl font-['Montserrat'] font-light mb-8 max-w-4xl mx-auto text-white lowercase">
+            <p className="text-base leading-6 text-[#F5F5F5] mb-8">
               {content.description}
             </p>
           </div>

--- a/client/src/site/ness/services/CrisisOpsPage.tsx
+++ b/client/src/site/ness/services/CrisisOpsPage.tsx
@@ -64,13 +64,14 @@ export default function NessCrisisOpsPage() {
       canonicalUrl={`https://${siteConfig.domain}/services/crisisops`}
     >
       {/* Hero Section */}
-      <section className="intro bg-[#121212] relative flex items-center justify-center" style={{ minHeight: "60vh" }}>
-        <div className="container mx-auto px-4 z-10">
-          <div className="text-center">
-            <h1 className="text-6xl md:text-7xl font-['Montserrat'] font-normal mb-6 text-white">
+      <section className="intro bg-hero-gradient relative flex items-center overflow-hidden" style={{ minHeight: '60vh' }}>
+        <div className="hero-vignette-right" />
+        <div className="container mx-auto px-4 z-10 flex items-center h-full">
+          <div className="hero-main-content">
+            <h1 className="text-[48px] font-['Montserrat'] font-normal text-white mb-6">
               {formatServiceName(content.title)}
             </h1>
-            <p className="text-xl md:text-2xl font-['Montserrat'] font-light mb-8 max-w-4xl mx-auto text-white lowercase">
+            <p className="text-base leading-6 text-[#F5F5F5] mb-8">
               {content.description}
             </p>
           </div>

--- a/client/src/site/ness/services/DevArchPage.tsx
+++ b/client/src/site/ness/services/DevArchPage.tsx
@@ -64,13 +64,14 @@ export default function NessDevArchPage() {
       canonicalUrl={`https://${siteConfig.domain}/services/devarch`}
     >
       {/* Hero Section */}
-      <section className="intro bg-[#121212] relative flex items-center justify-center" style={{ minHeight: "60vh" }}>
-        <div className="container mx-auto px-4 z-10">
-          <div className="text-center">
-            <h1 className="text-6xl md:text-7xl font-['Montserrat'] font-normal mb-6 text-white">
+      <section className="intro bg-hero-gradient relative flex items-center overflow-hidden" style={{ minHeight: '60vh' }}>
+        <div className="hero-vignette-right" />
+        <div className="container mx-auto px-4 z-10 flex items-center h-full">
+          <div className="hero-main-content">
+            <h1 className="text-[48px] font-['Montserrat'] font-normal text-white mb-6">
               {formatServiceName(content.title)}
             </h1>
-            <p className="text-xl md:text-2xl font-['Montserrat'] font-light mb-8 max-w-4xl mx-auto text-white lowercase">
+            <p className="text-base leading-6 text-[#F5F5F5] mb-8">
               {content.description}
             </p>
           </div>

--- a/client/src/site/ness/services/InfraOpsPage.tsx
+++ b/client/src/site/ness/services/InfraOpsPage.tsx
@@ -64,13 +64,14 @@ export default function NessInfraOpsPage() {
       canonicalUrl={`https://${siteConfig.domain}/services/infraops`}
     >
       {/* Hero Section */}
-      <section className="intro bg-[#121212] relative flex items-center justify-center" style={{ minHeight: "60vh" }}>
-        <div className="container mx-auto px-4 z-10">
-          <div className="text-center">
-            <h1 className="text-6xl md:text-7xl font-['Montserrat'] font-normal mb-6 text-white">
+      <section className="intro bg-hero-gradient relative flex items-center overflow-hidden" style={{ minHeight: '60vh' }}>
+        <div className="hero-vignette-right" />
+        <div className="container mx-auto px-4 z-10 flex items-center h-full">
+          <div className="hero-main-content">
+            <h1 className="text-[48px] font-['Montserrat'] font-normal text-white mb-6">
               {formatServiceName(content.title)}
             </h1>
-            <p className="text-xl md:text-2xl font-['Montserrat'] font-light mb-8 max-w-4xl mx-auto text-white lowercase">
+            <p className="text-base leading-6 text-[#F5F5F5] mb-8">
               {content.description}
             </p>
           </div>

--- a/client/src/site/ness/services/PrivacyPage.tsx
+++ b/client/src/site/ness/services/PrivacyPage.tsx
@@ -64,13 +64,14 @@ export default function NessPrivacyPage() {
       canonicalUrl={`https://${siteConfig.domain}/services/privacy`}
     >
       {/* Hero Section */}
-      <section className="intro bg-[#121212] relative flex items-center justify-center" style={{ minHeight: "60vh" }}>
-        <div className="container mx-auto px-4 z-10">
-          <div className="text-center">
-            <h1 className="text-6xl md:text-7xl font-['Montserrat'] font-normal mb-6 text-white">
+      <section className="intro bg-hero-gradient relative flex items-center overflow-hidden" style={{ minHeight: '60vh' }}>
+        <div className="hero-vignette-right" />
+        <div className="container mx-auto px-4 z-10 flex items-center h-full">
+          <div className="hero-main-content">
+            <h1 className="text-[48px] font-['Montserrat'] font-normal text-white mb-6">
               {formatServiceName(content.title)}
             </h1>
-            <p className="text-xl md:text-2xl font-['Montserrat'] font-light mb-8 max-w-4xl mx-auto text-white lowercase">
+            <p className="text-base leading-6 text-[#F5F5F5] mb-8">
               {content.description}
             </p>
           </div>

--- a/client/src/site/ness/services/SecOpsPage.tsx
+++ b/client/src/site/ness/services/SecOpsPage.tsx
@@ -64,13 +64,14 @@ export default function NessSecOpsPage() {
       canonicalUrl={`https://${siteConfig.domain}/services/secops`}
     >
       {/* Hero Section */}
-      <section className="intro bg-[#121212] relative flex items-center justify-center" style={{ minHeight: "60vh" }}>
-        <div className="container mx-auto px-4 z-10">
-          <div className="text-center">
-            <h1 className="text-6xl md:text-7xl font-['Montserrat'] font-normal mb-6 text-white">
+      <section className="intro bg-hero-gradient relative flex items-center overflow-hidden" style={{ minHeight: '60vh' }}>
+        <div className="hero-vignette-right" />
+        <div className="container mx-auto px-4 z-10 flex items-center h-full">
+          <div className="hero-main-content">
+            <h1 className="text-[48px] font-['Montserrat'] font-normal text-white mb-6">
               {formatServiceName(content.title)}
             </h1>
-            <p className="text-xl md:text-2xl font-['Montserrat'] font-light mb-8 max-w-4xl mx-auto text-white lowercase">
+            <p className="text-base leading-6 text-[#F5F5F5] mb-8">
               {content.description}
             </p>
           </div>

--- a/client/src/site/trustness/HomePage.tsx
+++ b/client/src/site/trustness/HomePage.tsx
@@ -40,25 +40,26 @@ export default function TrustnessHomePage() {
       canonicalUrl={`https://${siteConfig.domain}`}
     >
       {/* Hero Section */}
-      <section 
-        className="intro text-white bg-[#0b1016] relative flex items-center"
-        style={{ minHeight: "60vh" }}
+      <section
+        className="intro text-white bg-hero-gradient relative flex items-center overflow-hidden"
+        style={{ minHeight: '60vh' }}
       >
-        
-        <div className="container mx-auto px-4 relative z-10">
-          <div className="max-w-3xl mx-auto text-center">
-            <h1 className="mb-6 lowercase">
+        <div className="hero-vignette-right" />
+
+        <div className="container mx-auto px-4 relative z-10 flex items-center h-full">
+          <div className="hero-main-content">
+            <h1 className="text-[32px] font-['Montserrat'] font-medium mt-12 mb-6 lowercase">
               trustness<span className="text-[#00ade0]">.</span>
             </h1>
-            <p className="text-xl text-gray-300 mb-8">
-              {language === 'pt' && (pageContent?.content?.heroSubtitle || 
+            <p className="text-base leading-6 text-[#F5F5F5] mb-8">
+              {language === 'pt' && (pageContent?.content?.heroSubtitle ||
                 'privacidade, segurança da informação e compliance com foco em programas regulatórios e frameworks internacionais')}
-              {language === 'en' && (pageContent?.content?.heroSubtitleEn || 
+              {language === 'en' && (pageContent?.content?.heroSubtitleEn ||
                 'privacy, information security and compliance focused on regulatory programs and international frameworks')}
-              {language === 'es' && (pageContent?.content?.heroSubtitleEs || 
+              {language === 'es' && (pageContent?.content?.heroSubtitleEs ||
                 'privacidad, seguridad de la información y compliance con foco en programas regulatorios y frameworks internacionales')}
             </p>
-            <div className="flex flex-col sm:flex-row justify-center gap-4">
+            <div className="flex flex-col sm:flex-row justify-start gap-4">
               <a
                 href="#what-we-do"
                 className="bg-[#00ade0] hover:bg-opacity-90 text-white px-6 py-3 rounded lowercase"


### PR DESCRIPTION
## Summary
- tweak hero utilities to include gradient background and vignette overlay
- left-align `.hero-main-content` and adjust font styles
- support optional CTA in `HeroSection`
- update hero layout for all ness service pages
- align hero sections of trustness and forense homepages with new styles

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_68407fc624c88330888d076599956e12