### PR TITLE
Fix README admin section typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The API creates an administrator account at startup using the
 `ADMIN_USER` and `ADMIN_PASSWORD` environment variables.
 Define these variables (for example in a `.env` file) before running the
 development server so the admin user is created automatically.
-=======
 
 ## Database Notes
 


### PR DESCRIPTION
## Summary
- remove stray line from Admin credentials instructions

## Testing
- `grep -n "Admin credentials" README.md`


------
https://chatgpt.com/codex/tasks/task_b_68409ed2ec2883309bebdb8033255d6b