### PR TITLE
Use ES module imports for tailwind plugins

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
+import typography from "@tailwindcss/typography";
 
 export default {
   darkMode: ["class"],
@@ -86,5 +88,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
+  plugins: [tailwindcssAnimate, typography],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- refactor `tailwind.config.ts` to use ES module imports for `tailwindcss-animate` and `@tailwindcss/typography`

## Testing
- `npx tailwindcss --help` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_b_68409ed6815c833083df44a8e0240f52