### PR TITLE
Update hero main styles

### DIFF
--- a/client/src/assets/hero-main.css
+++ b/client/src/assets/hero-main.css
@@ -3,7 +3,7 @@
   position: relative;
   z-index: 10;
   text-align: left;
-  padding-left: 80px;
+  padding-left: var(--spacing-lg);
   max-width: 600px;
 }
 
@@ -13,7 +13,6 @@
   margin-top: 48px;
   margin-bottom: 1.5rem;
   font-family: 'Montserrat', sans-serif;
-  text-transform: lowercase;
   color: #ffffff;
   letter-spacing: -0.5px;
 }
@@ -23,7 +22,18 @@
   line-height: 24px;
   font-weight: 300;
   max-width: 800px;
-  text-transform: lowercase;
   margin-bottom: 2rem;
   color: #F5F5F5;
+}
+
+@media (max-width: 1024px) {
+  .hero-main-content {
+    padding-left: var(--spacing-md);
+  }
+}
+
+@media (max-width: 640px) {
+  .hero-main-content {
+    padding-left: var(--spacing-sm);
+  }
 }


### PR DESCRIPTION
## Summary
- fix hero-main left padding to use CSS variables
- remove forced lowercase styles from hero-main
- add responsive padding for tablet and mobile breakpoints

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_b_6840a6c885b08330b4509e93b3d9f348