### PR TITLE
Reduce hero section height

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -138,7 +138,7 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    min-height: 100vh;
+    min-height: 60vh;
     padding-left: 5vw;
     background-color: #0A0F1F;
     position: relative;


### PR DESCRIPTION
## Summary
- shorten the hero min-height from 100vh to 60vh in `client/src/index.css`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_6840a87873a48330ac77d149e61c64e9