### PR TITLE
Add HomePage translation fallbacks

### DIFF
--- a/client/src/site/ness/HomePage.tsx
+++ b/client/src/site/ness/HomePage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useI18n } from '@/lib/i18n';
 import { useSite } from '../SiteContext';
 import SiteLayout from '../layout/SiteLayout';
+import homeTranslations from './translations/home';
 
 // Importando componentes da página existente
 import HeroSection from '@/components/sections/HeroSection';
@@ -12,6 +13,18 @@ import SpinoffsSection from '@/components/sections/SpinoffsSection';
 export default function NessHomePage() {
   const { siteConfig } = useSite();
   const { language } = useI18n();
+
+  const featuredTitleFallback = {
+    pt: homeTranslations.pt.featuredSectionTitle,
+    en: homeTranslations.en.featuredSectionTitle,
+    es: homeTranslations.es.featuredSectionTitle
+  };
+
+  const featuredDescFallback = {
+    pt: homeTranslations.pt.featuredSectionDescription,
+    en: homeTranslations.en.featuredSectionDescription,
+    es: homeTranslations.es.featuredSectionDescription
+  };
   
   // Buscar conteúdo da página inicial específico para o site ness
   const { data: pageContent, isLoading } = useQuery({
@@ -83,11 +96,11 @@ export default function NessHomePage() {
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
             <h2 className="text-gray-800 mb-4 lowercase">
-              {pageContent?.content && JSON.parse(pageContent.content).featuredSectionTitle || 'tecnologia modular para o essencial invisível'}
+              {pageContent?.content && JSON.parse(pageContent.content).featuredSectionTitle || featuredTitleFallback[language]}
             </h2>
             <p className="text-gray-600 max-w-3xl mx-auto">
-              {pageContent?.content && JSON.parse(pageContent.content).featuredSectionDescription || 
-                'nossas soluções são modulares, escaláveis e atuam nos bastidores — porque o essencial, a estrutura que sustenta tudo, deve funcionar com precisão e ser invisível para quem depende dela.'}
+              {pageContent?.content && JSON.parse(pageContent.content).featuredSectionDescription ||
+                featuredDescFallback[language]}
             </p>
           </div>
           

--- a/client/src/site/ness/translations/home.ts
+++ b/client/src/site/ness/translations/home.ts
@@ -1,0 +1,21 @@
+import { Language } from '@/lib/i18n';
+
+const localizedHomeContent: Record<Language, { featuredSectionTitle: string; featuredSectionDescription: string }> = {
+  pt: {
+    featuredSectionTitle: 'tecnologia modular para o essencial invisível',
+    featuredSectionDescription:
+      'nossas soluções são modulares, escaláveis e atuam nos bastidores — porque o essencial, a estrutura que sustenta tudo, deve funcionar com precisão e ser invisível para quem depende dela.'
+  },
+  en: {
+    featuredSectionTitle: 'modular technology for the invisible essential',
+    featuredSectionDescription:
+      'our solutions are modular, scalable and work behind the scenes — because the essential structure that supports everything must operate precisely and remain invisible to those who rely on it.'
+  },
+  es: {
+    featuredSectionTitle: 'tecnología modular para lo esencial invisible',
+    featuredSectionDescription:
+      'nuestras soluciones son modulares, escalables y actúan tras bambalinas — porque lo esencial, la estructura que lo sostiene todo, debe funcionar con precisión y ser invisible para quien depende de ella.'
+  }
+};
+
+export default localizedHomeContent;


### PR DESCRIPTION
## Summary
- add `home.ts` translation file for NESS site
- switch HomePage fallbacks to use localized strings

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_6840b15f424c8330a8e37a8e50886132