### PR TITLE
Add dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ temporary hack has been removed.
 ## Environment variables
 
 Several values are read from the environment when the server starts. Copy
-`.env.example` to `.env` and fill in the following variables:
+`.env.example` to `.env` and fill in the following variables. The server
+automatically loads variables from this file at startup:
 
 - `DATABASE_URL` - connection string for your database
 - `SESSION_SECRET` - random string used to sign session cookies

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^16.5.0",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -4878,6 +4879,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "dotenv": "^16.5.0",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";


### PR DESCRIPTION
## Summary
- install `dotenv`
- import dotenv in the server bootstrap
- update README on `.env` loading

## Testing
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_6845af76281c8330a0574aca928d9c72