### PR TITLE
Add helmet middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "express": "^4.21.2",
         "express-session": "^1.18.1",
         "framer-motion": "^11.18.2",
+        "helmet": "^8.1.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.453.0",
         "memorystore": "^1.6.7",
@@ -6215,6 +6216,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "express": "^4.21.2",
     "express-session": "^1.18.1",
     "framer-motion": "^11.18.2",
+    "helmet": "^8.1.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.453.0",
     "memorystore": "^1.6.7",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,23 @@
 import express, { type Request, Response, NextFunction } from "express";
+import helmet from "helmet";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "https:", "'unsafe-inline'"],
+        imgSrc: ["'self'", "data:", "https:"],
+      },
+    },
+    crossOriginResourcePolicy: false,
+  }),
+);
 
 app.use((req, res, next) => {
   const start = Date.now();


### PR DESCRIPTION
## Summary
- add `helmet` to dependencies
- apply helmet with minimal CSP and resource policy in Express

## Testing
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_6845af6e58488330b2e680b56fbf4e16